### PR TITLE
Remove support for multiple polygons on each endpoint

### DIFF
--- a/src/main/static/js/application.js
+++ b/src/main/static/js/application.js
@@ -176,7 +176,6 @@ weightedOverlay = (function() {
         }
 
         var geoJson = JSON.stringify(map.getMaskGeoJSON());
-        var polyMask = JSON.stringify([geoJson]);
 
         $.ajax({
             url: 'gt/breaks',
@@ -185,7 +184,7 @@ weightedOverlay = (function() {
                 layers: getLayers(),
                 weights: getWeights(),
                 numBreaks: numBreaks,
-                polyMask: polyMask
+                polyMask:geoJson
             },
             dataType: "json",
             success: function(r) {
@@ -199,7 +198,7 @@ weightedOverlay = (function() {
                     layers: layerNames,
                     weights: getWeights(),
                     colorRamp: colorRamp,
-                    polyMask: polyMask,
+                    polyMask: geoJson,
                     attribution: 'Azavea'
                 });
 

--- a/src/test/scala/ModelingServiceLogicSpec.scala
+++ b/src/test/scala/ModelingServiceLogicSpec.scala
@@ -178,7 +178,7 @@ class ModelingServiceLogicSpec
   test("Layer mask from string") {
     val rs = logic.createRasterSource("Raster2", rasterExtent)
     val layerMask = Map("Raster1" -> Array(1))
-    val result = logic.getMaskedModel(rs, None, Some(layerMask), rasterExtent)
+    val result = logic.getMaskedModel(rs, "", Some(layerMask), rasterExtent)
     assert(tilesAreEqual(result.get,
       createTile(
         Array(0, n, 0, n, 0,


### PR DESCRIPTION
Since we will be combining geometries via PostGIS, we decided that we
could simplify this endpoint by requiring that the `polyMask` param only
contain a single GeoJson blob.
