### PR TITLE
Add `srid` parameter to all endpoints to remove ambiguity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ Arguments:
 | layers     | Yes       | String  | Layer names (comma delimited). Should match the source raster file names.
 | weights    | Yes       | String  | Layer weights (comma delimited integers) for corresponding layer.
 | numBreaks  | Yes       | Int     | Number of result class breaks.
+| srid       | Yes       | Int     | Spatial Reference Identifier. Acceptable values are `3857` or `4326`.
 | threshold  |           | Int     | Exclude values lower than this value in class breaks calculation. (Default: `NODATA`)
-| polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons projected in WebMercator.
+| polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons.
 | layerMask  |           | JSON    | Exclude values from result. Map of layer names to selected raster values. Format: `{ LayerName: [1, 2, 3], ...}`
 
 Sample output:
@@ -105,9 +106,10 @@ Arguments:
 | layers     | Yes       | String  | Layer names (comma delimited). Should match the source raster file names.
 | weights    | Yes       | String  | Layer weights (comma delimited integers) for corresponding layer.
 | breaks     | Yes       | String  | Class breaks (comma delimited integers)
+| srid       | Yes       | Int     | Spatial Reference Identifier. Acceptable values are `3857` or `4326`.
 | colorRamp  |           | String  | Color ramp name. (Default: `blue-to-red`)
 | threshold  |           | Int     | Exclude values lower than this value in class breaks calculation. (Default: `NODATA`)
-| polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons projected in WebMercator.
+| polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons.
 | layerMask  |           | JSON    | Exclude values from result. Map of layer names to selected raster values. Format: `{ LayerName: [1, 2, 3], ...}`
 
 ### /gt/histogram
@@ -122,6 +124,7 @@ Arguments:
 |------------|-----------|---------|--------------|
 | bbox       | Yes       | String  | Bounding box projected as WebMercator. Format: `xmin,ymin,xmax,ymax`
 | layer      | Yes       | String  | Layer name. Should match the filename of the source raster.
+| srid       | Yes       | Int     | Spatial Reference Identifier. Acceptable values are `3857` or `4326`.
 | polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons.
 
 Sample output:
@@ -142,7 +145,15 @@ Arguments:
 | Name       | Required? | Type    |  Description |
 |------------|-----------|---------|--------------|
 | layer      | Yes       | String  | Layer name.
-| coords     | Yes       | String  | Comma delimited list of values formatted like `Name,X,Y,...`. Coordinates should be projected as LatLng. (Example: `Tree1,0,0,Tree2,100,100`)
+| coords     | Yes       | String  | Comma delimited list of values formatted like `Name,X,Y,...`.
+| srid       | Yes       | Int     | Spatial Reference Identifier. Acceptable values are `3857` or `4326`.
+
+Sample request body:
+
+    layer=nlcd
+    &srid=4326
+    &coords=Tree1,-118.24722290039064,33.972975771726006,
+            Tree2,-117.91488647460938,33.81680727566875
 
 Sample output:
 


### PR DESCRIPTION
It was confusing that some endpoints expected LatLng projection while
others expected WebMercator. As a result, you wouldn't know which
projection to use without referencing the documentation.

Since it is sometimes convenient to use LatLng, and at other times
more convenient to use WebMercator, I decided to add a parameter to each
endpoint to specify which projection the consumer is using.
