### PR TITLE
Add combined jar project that produces a single jar from which all modeling services can be run

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -81,7 +81,7 @@ object OTMModelingBuild extends Build {
   )
 
   lazy val root: Project =
-    Project("otm-modeling", file(".")).aggregate(summary, tile)
+    Project("otm-modeling", file(".")).aggregate(summary, tile, combined)
 
   lazy val rootSettings =
     Seq(
@@ -137,4 +137,17 @@ object OTMModelingBuild extends Build {
     Seq(
       name := "otm-modeling-tile"
     ) ++ rootSettings
+
+  lazy val combinedSettings =
+    Seq(
+      name := "otm-modeling",
+      mainClass := Some("org.opentreemap.modeling.Main")
+    ) ++ rootSettings
+
+  lazy val combined = Project("combined",  file("combined"))
+    .settings(combinedSettings:_*)
+    .dependsOn(common)
+    .dependsOn(tile)
+    .dependsOn(summary)
+
 }

--- a/summary/examples/docker/test.sh
+++ b/summary/examples/docker/test.sh
@@ -23,7 +23,7 @@ printf "Wait For Service Startup\n"
 sleep 3
 
 printf "Submit Jar\n"
-curl --silent --data-binary @../../target/scala-2.10/otm-modeling-summary-assembly-0.0.1.jar 'http://localhost:8090/jars/summary'
+curl --silent --data-binary @../../../combined/target/scala-2.10/otm-modeling-assembly-0.0.1.jar 'http://localhost:8090/jars/summary'
 
 printf "\nCreate Context\n"
 curl --silent --data "" 'http://localhost:8090/contexts/summary-context'

--- a/tile/examples/docker/test.sh
+++ b/tile/examples/docker/test.sh
@@ -13,7 +13,7 @@ MODELING_TILE_HOME=/opt/otm-modeling-tile
 DATAHUB_AWS_PROFILE=otm-test
 printf "Tiles will be requested using the $DATAHUB_AWS_PROFILE AWS profile\n"
 
-cp $PWD/../../target/scala-2.10/otm-modeling-tile-assembly-0.0.1.jar $PWD/home/otm-modeling-tile.jar
+cp $PWD/../../../combined/target/scala-2.10/otm-modeling-assembly-0.0.1.jar $PWD/home/otm-modeling.jar
 
 printf "Run Container\n"
 docker run \
@@ -28,7 +28,7 @@ docker run \
   quay.io/azavea/spark:latest \
   /opt/spark/bin/spark-submit \
   --master local[*] \
-  otm-modeling-tile.jar 2>&1
+  otm-modeling.jar 2>&1
 
 printf "Wait For Service Startup\n"
 sleep 7


### PR DESCRIPTION
Producing a single versioned jar for both the tile and summary services will simplify provisioning.

The plan is to produce a version jar as an artifact that is pulled in and deployed onto our modeling servers. Moving the version number to the top of the file makes it a little easier to find.

The testing process is the same as #63

Connects to #59 
