### PR TITLE
Return weighted overlay tiles for all zoom levels

### DIFF
--- a/tile/src/main/scala/TileServiceLogic.scala
+++ b/tile/src/main/scala/TileServiceLogic.scala
@@ -46,18 +46,16 @@ trait TileServiceLogic {
             val reader = tileReader.read(layer, z)
             reader(SpatialKey(x, y))
           } else {
-            // TODO: Fix this to work with the latest API
-            throw new Exception(s"Zooming above $DEFAULT_ZOOM is not supported")
-            // val layerId = LayerId(layer, DEFAULT_ZOOM)
-            // val reader = tileReader.read(layerId)
-            // val rmd = getMetadata(sc, tileReader, layerId)
-            // val layoutLevel = ZoomedLayoutScheme(rmd.crs).levelForZoom(rmd.extent, z)
-            // val mapTransform = MapKeyTransform(rmd.crs, layoutLevel.tileLayout.layoutCols, layoutLevel.tileLayout.layoutRows)
-            // val targetExtent = mapTransform(x, y)
-            // val gb @ GridBounds(nx, ny, _, _) = rmd.mapTransform(targetExtent)
-            // val sourceExtent = rmd.mapTransform(nx, ny)
-            // val largerTile = reader(SpatialKey(nx, ny))
-            // largerTile.resample(sourceExtent, RasterExtent(targetExtent, 256, 256))
+            val layerId = LayerId(layer, DEFAULT_ZOOM)
+            val reader = tileReader.read(layerId)
+            val rmd = getMetadata(sc, tileReader, layerId)
+            val layoutLevel = ZoomedLayoutScheme(rmd.crs).levelForZoom(rmd.extent, z)
+            val mapTransform = MapKeyTransform(rmd.crs, layoutLevel.layout.layoutCols, layoutLevel.layout.layoutRows)
+            val targetExtent = mapTransform(x, y)
+            val gb @ GridBounds(nx, ny, _, _) = rmd.mapTransform(targetExtent)
+            val sourceExtent = rmd.mapTransform(nx, ny)
+            val largerTile = reader(SpatialKey(nx, ny))
+            largerTile.resample(sourceExtent, RasterExtent(targetExtent, 256, 256))
           }
         // Convert Byte tiles to Int so that math operations do not overflow
         tile.convert(TypeInt).map(_ * weight)


### PR DESCRIPTION
The tile resampling code was previously commented out because the API changed, but the change was actually just a simple property renaming.

From

```
MapKeyTransform(rmd.crs,
                layoutLevel.tileLayout.layoutCols,
                layoutLevel.tileLayout.layoutRows)
```

to

```
MapKeyTransform(rmd.crs,
                layoutLevel.layout.layoutCols,
                layoutLevel.layout.layoutRows)
```

---
##### Testing

Rebuild the assembly JAR and copy it to the project root (from `{project root}/combined/target/scala-2.10/otm-modeling-assembly-0.0.1.jar` to `{project root}/otm-modeling-0.0.1.jar`), which is mounted in the modeling VM. Inside the VM the updated JAR should be available at `/opt/modeling/otm-modeling-0.0.1.jar`. Restart the `otm-modeling-tile` service and then test loading tiles at all zoom levels on the modeling map. 

---

Connects to #77
