### PR TITLE
Reproject polygon passed to histogram endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-*~
 project/boot
 project/plugins/project
 project/plugins/target
 project/target
 target
 build
+combined
+data
 .ensime
 TAGS
 \#*#
@@ -13,8 +14,6 @@ TAGS
 .lib
 *.aux.xml
 *.jar
-data/catalog/*.json
-data/catalog/*.arg
 Thumbs.db
 *.swp
 

--- a/summary/examples/request-histogram.json
+++ b/summary/examples/request-histogram.json
@@ -1,7 +1,8 @@
 {
     "input": {
         "zoom": 11,
+        "srid": 4326,
         "layer": "nlcd-zoomed",
-        "polyMask": "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"crs\":\"EPSG:3857\",\"coordinates\":[[[-13193901,4044824],[-13179120,4044824],[-13189120,4042396],[-13193901,4042396],[-13193901,4044824]]]}}]}"
+        "polyMask": "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-93.38584899902344,45.04344838585674],[-93.3013916015625,45.017243565102596],[-93.39546203613281,44.987627391684704],[-93.38584899902344,45.04344838585674]]]}}]}"
     }
 }

--- a/summary/src/main/scala/HistogramJobConfig.scala
+++ b/summary/src/main/scala/HistogramJobConfig.scala
@@ -9,8 +9,12 @@ object HistogramJobConfig extends VectorHandling {
     val polyMaskParam = config.getString("input.polyMask")
     val zoom = config.getInt("input.zoom")
     val layerId = LayerId(config.getString("input.layer"), zoom)
-    // TOOD: Read CRS from config
-    new HistogramJobConfig(layerId, parsePolyMaskParam(polyMaskParam))
+    val srid = config.getInt("input.srid")
+    val polys = reprojectPolygons(
+      parsePolyMaskParam(polyMaskParam),
+      srid
+    )
+    new HistogramJobConfig(layerId, polys)
   }
 }
 


### PR DESCRIPTION
Also, add more build artifacts to .gitignore

Testing:

```
curl --silent --data-binary @summary/examples/request-histogram.json 'http://localhost:8081/sjs/jobs?sync=true&context=modeling&appName=otm-modeling-0.0.1&classPath=org.opentreemap.modeling.HistogramJob'

{
  "status": "OK",
  "result": {
    "elapsed": 7041,
    "envelope": [-10396735.276264818, 5619573.882497872, -10386263.40338975, 5628364.140750667],
    "histogram": [[11, 227], [21, 6807], [22, 14020], [23, 5842], [24, 2418], [41, 278], [71, 26], [81, 17], [90, 47],
  [95, 119]]
  }

```
