### PR TITLE
Work around GeoTrellis bug to correctly combine mask and tile

### DIFF
--- a/tile/src/main/scala/TileLayerMasking.scala
+++ b/tile/src/main/scala/TileLayerMasking.scala
@@ -15,7 +15,9 @@ trait TileLayerMasking {
   def layerTileMask(layerMasks: Iterable[Tile])(tile: Tile): Tile = {
     if (layerMasks.size > 0) {
       layerMasks.foldLeft(tile) { (acc, mask) =>
-        acc.combine(mask) { (z, maskValue) =>
+        //acc.combine(mask) { (z, maskValue) =>
+        // TODO: restore above line after switching to GeoTrellis 0.10
+        acc.combine(mask.convert(TypeInt).toArrayTile) { (z, maskValue) =>
           if (isData(maskValue)) z
           else NODATA
         }


### PR DESCRIPTION
Connects #76 

Testing: 
1) Open phillytreemap/modeling
2) Increase the weight of "Percent Vacant Housing Units" to show prioritization tiles
3) In Masks > Land Cover, click "High Values" to show only low values

Most of the tiled area is masked, but we still see data on the Delaware river.
