### PR TITLE
Restore Tile and RasterRDD polygon masking

### DIFF
--- a/tile/src/main/scala/LayerMasking.scala
+++ b/tile/src/main/scala/LayerMasking.scala
@@ -4,14 +4,17 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.spark._
 import geotrellis.spark.op.local._
+import geotrellis.spark.op.local.spatial._
 
 trait LayerMasking {
 
   /** Combine multiple polygons into a single mask raster. */
   def polyMask(polyMasks: Iterable[Polygon])(model: RasterRDD[SpatialKey]): RasterRDD[SpatialKey] = {
-    // TODO: Pull in an updated Geotrellis when this is complete and merged
-    // https://github.com/zifeo/geotrellis/commit/d63608cb7d77c0358a5dd8118f6289d6d9366799
-    model
+    if (polyMasks.size > 0) {
+      model.mask(polyMasks)
+    } else {
+      model
+    }
   }
 
   /** Combine multiple rasters into a single raster.

--- a/tile/src/main/scala/TileLayerMasking.scala
+++ b/tile/src/main/scala/TileLayerMasking.scala
@@ -1,15 +1,51 @@
 package org.opentreemap.modeling
 
+import scala.math.{Pi, pow}
+
 import geotrellis.raster._
+import geotrellis.raster.rasterize._
 import geotrellis.vector._
 import geotrellis.spark._
 
 trait TileLayerMasking {
 
-  def polyTileMask(polyMasks: Iterable[Polygon])(tile: Tile): Tile = {
-    // TODO: Pull in an updated Geotrellis when this is complete and merged
-    // https://github.com/zifeo/geotrellis/commit/d63608cb7d77c0358a5dd8118f6289d6d9366799
-    tile
+  val tileSize:Int = 256
+  val initialResolution:Double = 2 * Pi * 6378137 / tileSize
+  val originShift:Double = 2 * Pi * 6378137 / 2.0
+
+  def resolution(zoom:Int):Double = {
+    initialResolution / pow(2, zoom)
+  }
+
+  def pixelsToMeters(px:Int, py:Int, zoom:Int):(Double, Double) = {
+    val res = resolution(zoom)
+    val mx = px * res - originShift
+    val my = py * res - originShift
+    return (mx, my)
+  }
+
+  def webMercatorTileExtent(tx:Int, ty:Int, zoom:Int):Extent = {
+    // Convert ZXY to TMS (The Y value needs to be "flipped")
+    val fy = pow(2, zoom).toInt - ty - 1
+    val (minx, miny) = pixelsToMeters( tx*tileSize, fy*tileSize, zoom )
+    val (maxx, maxy) = pixelsToMeters( (tx+1)*tileSize, (fy+1)*tileSize, zoom )
+    Extent( minx, miny, maxx, maxy )
+  }
+
+  def polyTileMask(polyMasks: Iterable[Polygon], z:Int, x:Int, y:Int)(tile: Tile): Tile = {
+    if (polyMasks.size > 0) {
+      val (cols, rows) = tile.dimensions
+      val re = RasterExtent(tile, webMercatorTileExtent(x, y, z))
+      val result = ArrayTile.empty(tile.cellType, cols, rows)
+      for(g <- polyMasks) {
+        Rasterizer.foreachCellByGeometry(g, re) { (col: Int, row: Int) =>
+          result.set(col, row, tile.get(col, row))
+        }
+      }
+      result:Tile
+    } else {
+      tile
+    }
   }
 
   def layerTileMask(layerMasks: Iterable[Tile])(tile: Tile): Tile = {

--- a/tile/src/main/scala/TileService.scala
+++ b/tile/src/main/scala/TileService.scala
@@ -156,7 +156,7 @@ trait TileService extends HttpService
                 val unmasked = weightedOverlay(implicitly, tileReader, layers, weights, z, x, y)
                 val masked = applyTileMasks(
                   unmasked,
-                  polyTileMask(polys),
+                  polyTileMask(polys, z, x, y),
                   layerTileMask(parseLayerTileMaskParam(implicitly, parsedLayerMask, z, x, y)),
                   thresholdTileMask(threshold)
                 )


### PR DESCRIPTION
Masking operations for RDDs were updated in GeoTrellis d63608c so I was able to easily restore the masking functionality in LayerMasking.scala. This API is still available in GeoTrellis 0.10.0.

A single tile, specified by zoom level, x, and y, does not have any geographic information associated with it. GeoTrellis has an API to identify the cells in tile that are within a specified polygon (Rasterizer.foreachCellByGeometry), but it requires a geographic extent as an argument. To obtain the required extent, I have referenced the code at http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/ and added the required helper functions.

---
##### Known issues

When the masked area contains fewer than ten discrete values, the scaling produces values that do not look correct.

---
##### Testing
1. Open phillytreemap/modeling
2. Increase Percent Vacant Housing Units to show prioritization tiles. Zoom into the Strawberry Mansion neighborhood area
3. In the "Masks" section, check Philadelphia Neighborhood > Strawberry Mansion

Unmasked

<img width="1005" alt="screen shot 2016-03-23 at 11 22 25 pm" src="https://cloud.githubusercontent.com/assets/17363/14009985/407b4f46-f14e-11e5-8dfc-befb9f659250.png">

Masked

<img width="1110" alt="screen shot 2016-03-23 at 11 22 45 pm" src="https://cloud.githubusercontent.com/assets/17363/14009987/44e06a08-f14e-11e5-85d2-d7ff346f54d4.png">

---

Connects to #87
