### PR TITLE
Make sure color ramp covers all values in image

### DIFF
--- a/tile/src/main/scala/TileServiceLogic.scala
+++ b/tile/src/main/scala/TileServiceLogic.scala
@@ -57,7 +57,7 @@ trait TileServiceLogic
 
   def renderTile(tile: Tile, breaks: Seq[Int], colorRamp: String): Png = {
     val cr = ColorRampMap.getOrElse(colorRamp, ColorRamps.BlueToRed)
-    val map = ColorMap(breaks.toArray, cr)
+    val map = ColorMap(breaks.toArray, cr).withBoundaryType(LessThanOrEqualTo)
     tile.renderPng(map)
   }
 


### PR DESCRIPTION
Connects #94 

To test, run `scripts/endpoints.sh` and examine ~/tile.png
