### PR TITLE
Get layer's max zoom from metadata instead of from a hard-coded constant

### DIFF
--- a/tile/src/main/scala/TileService.scala
+++ b/tile/src/main/scala/TileService.scala
@@ -145,11 +145,11 @@ trait TileService extends HttpService
                   srid
                 )
 
-                val unmasked = weightedOverlay(implicitly, tileReader, layers, weights, z, x, y)
+                val unmasked = weightedOverlay(implicitly, catalog, tileReader, layers, weights, z, x, y)
                 val masked = applyTileMasks(
                   unmasked,
                   polyTileMask(polys, z, x, y),
-                  layerTileMask(TileGetter.getMaskTiles(implicitly, tileReader, parsedLayerMask, z, x, y)),
+                  layerTileMask(TileGetter.getMaskTiles(implicitly, catalog, tileReader, parsedLayerMask, z, x, y)),
                   thresholdTileMask(threshold)
                 )
 

--- a/tile/src/main/scala/TileServiceLogic.scala
+++ b/tile/src/main/scala/TileServiceLogic.scala
@@ -11,7 +11,6 @@ import geotrellis.raster.render._
 
 trait TileServiceLogic
 {
-  val DATA_TILE_MAX_ZOOM = 11
   val BREAKS_ZOOM = 8
 
   def addTiles(t1: Tile, t2: Tile): Tile = {
@@ -19,15 +18,15 @@ trait TileServiceLogic
   }
 
   def weightedOverlay(implicit sc: SparkContext,
+                      catalog: S3LayerReader,
                       tileReader: S3ValueReader,
                       layers:Seq[String],
                       weights:Seq[Int],
                       z:Int,
                       x:Int,
                       y:Int): Tile = {
-    // TODO: Handle layers with different pyramids instead of using DATA_TILE_MAX_ZOOM
     val tiles = layers.map { layer =>
-      TileGetter.getTileWithZoom(sc, tileReader, layer, z, x, y, DATA_TILE_MAX_ZOOM)
+      TileGetter.getTileWithZoom(sc, catalog, tileReader, layer, z, x, y)
     }
     val anyFloats = tiles.exists(tile => tile.cellType.isFloatingPoint)
     val targetCellType = if (anyFloats) FloatConstantNoDataCellType else IntConstantNoDataCellType


### PR DESCRIPTION
Also we use 512x512 tiles, not 256x256

Connects #96

Testing:

The "Mean Temperature" raster should now display at all zoom levels (including the default).
