### PR TITLE
Use cacheing proxy for S3 requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ TAGS
 Thumbs.db
 *.swp
 
+docker-s3-proxy-cache

--- a/common/src/main/scala/S3CatalogReading.scala
+++ b/common/src/main/scala/S3CatalogReading.scala
@@ -13,27 +13,43 @@ trait S3CatalogReading {
   final val bucket = "azavea-datahub"
   final val prefix = "catalog"
 
+
   var _catalog: S3LayerReader = null
   def catalog(implicit sc: SparkContext): S3LayerReader = {
     // we want to re-use the reference because AttributeStore performs caching in look-ups required for each request.
     // this saves ~200ms per request
-    if (null != _catalog)
-      _catalog
-    else {
-      val attributeStore = new S3AttributeStore("azavea-datahub", "catalog")
-      _catalog = new S3LayerReader(attributeStore)
-      _catalog
+    if (null == _catalog) {
+      val attributeStore = new S3AttributeStore(bucket, prefix)
+      _catalog = new S3ProxyLayerReader(attributeStore)
     }
+    _catalog
   }
 
   var _tileReader: S3ValueReader = null
   def tileReader(implicit sc: SparkContext):  S3ValueReader = {
-    if (null != _tileReader)
-      _tileReader
-    else {
-      _tileReader = S3ValueReader(bucket, prefix)
-      _tileReader
+    if (null == _tileReader) {
+      _tileReader = S3ProxyValueReader(bucket, prefix)
     }
+    _tileReader
+  }
+
+  // TODO: Eliminate these "NoProxy" versions once the summary service container knows about the s3-proxy-cache container
+
+  var _catalogNoProxy: S3LayerReader = null
+  def catalogNoProxy(implicit sc: SparkContext): S3LayerReader = {
+    if (null == _catalogNoProxy) {
+      val attributeStore = new S3AttributeStore(bucket, prefix)
+      _catalogNoProxy = new S3LayerReader(attributeStore)
+    }
+    _catalogNoProxy
+  }
+
+  var _tileReaderNoProxy: S3ValueReader = null
+  def tileReaderNoProxy(implicit sc: SparkContext):  S3ValueReader = {
+    if (null == _tileReaderNoProxy) {
+      _tileReaderNoProxy = S3ValueReader(bucket, prefix)
+    }
+    _tileReaderNoProxy
   }
 
   def metadata(implicit sc: SparkContext, layerId: LayerId): TileLayerMetadata[SpatialKey] =
@@ -42,7 +58,7 @@ trait S3CatalogReading {
       .readMetadata[TileLayerMetadata[SpatialKey]](layerId)
 
   def queryAndCropLayer(implicit sc: SparkContext, layerId: LayerId, extent: Extent): TileLayerRDD[SpatialKey] = {
-    catalog.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
+    catalogNoProxy.query[SpatialKey, Tile, TileLayerMetadata[SpatialKey]](layerId)
       .where(Intersects(extent))
       .result
   }

--- a/common/src/main/scala/S3ProxyReaders.scala
+++ b/common/src/main/scala/S3ProxyReaders.scala
@@ -1,0 +1,44 @@
+package org.opentreemap.modeling
+
+import com.amazonaws.Protocol
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.s3.{S3ClientOptions, AmazonS3Client => AWSAmazonS3Client}
+import geotrellis.spark.io.AttributeStore
+import geotrellis.spark.io.s3._
+import org.apache.spark.SparkContext
+
+
+class S3ProxyLayerReader(attributeStore: AttributeStore)(implicit sc: SparkContext)
+  extends S3LayerReader(attributeStore) {
+  override def rddReader =
+    new S3RDDReader {
+      def getS3Client = () => S3ProxyClient()
+    }
+}
+
+class S3ProxyValueReader(attributeStore: AttributeStore)
+  extends S3ValueReader(attributeStore) {
+  override val s3Client = S3ProxyClient()
+}
+
+object S3ProxyValueReader {
+  def apply(bucket: String, prefix: String): S3ValueReader =
+    new S3ProxyValueReader(new S3AttributeStore(bucket, prefix))
+}
+
+object S3ProxyClient {
+  def apply() = {
+    val config = S3Client.defaultConfiguration
+    config.setProtocol(Protocol.HTTP)
+    // TODO: get proxy host and port from application.conf (but avoid
+    // Spark "object not serializable" runtime exception).
+    config.setProxyHost("s3-proxy-cache")
+    config.setProxyPort(80)
+    val client = new AWSAmazonS3Client(new DefaultAWSCredentialsProviderChain(), config)
+    // Generate "path-style" URLs (s3.amazonaws.com/bucket/object)
+    // instead of "virtual-hosted-style" URLs (bucket.s3.amazonaws.com/object)
+    // because that's what our cacheing proxy is expecting
+    client.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true))
+    new AmazonS3Client(client)
+  }
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -13,7 +13,7 @@ object Version {
   val modeling     = "0.0.1"
 
   val geotools     = "8.0-M4"
-  val geotrellis   = "0.10.0"
+  val geotrellis   = "0.10.1"
   val scala        = "2.10.6"
   val scalatest    = "2.2.1"
   val spray        = "1.3.2"

--- a/summary/src/main/scala/PointValuesJob.scala
+++ b/summary/src/main/scala/PointValuesJob.scala
@@ -22,7 +22,7 @@ object PointValuesJob
   override def runJob(sc: SparkContext, config: Config): Any = {
     val startTime = System.currentTimeMillis
     val params = PointValuesJobConfig(config)
-    val reader = tileReader(sc).reader[SpatialKey, Tile](params.layerId)
+    val reader = tileReaderNoProxy(sc).reader[SpatialKey, Tile](params.layerId)
     val values = getValuesAtPoints(reader, metadata(sc, params.layerId))(params.pointsWithIds)
     val coords = values map {
       case (id, point, value) => Vector(id, point.x, point.y, value)


### PR DESCRIPTION
Also upgrade to GeoTrellis 0.10.1

Requires azavea/docker-s3-proxy-cache#1
Connects #105
Connects OpenTreeMap/otm-addons#1183
Connects OpenTreeMap/otm-addons#1184
Testing:
1. Clone https://github.com/azavea/docker-s3-proxy-cache into `otm-cloud/src/otm-modeling`
2. Edit `docker-s3-proxy-cache/etc/nginx/conf.d/default.conf` to contain `azavea-datahub` for `BUCKET` and an appropriate `ACCESS_KEY` and `SECRET_KEY`.
3. In your modeling VM, `sudo docker-compose up`
4. In your modeling VM, edit `/etc/init/otm-modeling-tile.conf` and add these arguments to `docker run`:

```
  --link s3-proxy-cache:s3-proxy-cache \
  --net dockers3proxycache_default \
```
1. Rebuild the modeling tile service
2. In OTM modeling, set prioritization weights. The shell running `docker-compose` should show S3 requests, and they should go much faster when the same tile is requested again.
