### PR TITLE
In rebuild.sh, restart tile service by restarting docker container

### DIFF
--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -43,5 +43,5 @@ curl -X POST "http://$sjs/contexts/$context"
 # The modeling project directory is shared into the VM at
 # /opt/modeling and the tile service loads the JAR from that path
 cp $jarpath .
-# Restart the tile service to load the new JAR
-vagrant ssh $vagrantvm -c "sudo service otm-modeling-tile restart"
+# Restart the tile service container to load the new JAR
+vagrant ssh $vagrantvm -c "sudo docker restart otm-modeling-tile"


### PR DESCRIPTION
There is no longer an upstart script for the tile service

I think it's OK to not test this.
