### PR TITLE
Use `classBreaksExactInt` rather than `classBreaks`

### DIFF
--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -4,10 +4,8 @@
 # $ SJS_HOST=33.33.34.48 SJS_PORT=8090 ./scripts/rebuild.sh
 
 # 1. Build the combined modeling assembly JAR
-# 2. POST the JAR to Spark Job Server
-# 3. Restart the Spark context in Spark Job Server
-# 4. Copy the JAR to the project root, mounted in the vagrant VM
-# 5. Restart the tile service within the Vagrant VM
+# 2. Copy the JAR to the project root, mounted in the vagrant VM
+# 3. Restart the tile service within the Vagrant VM
 
 set -e
 set -x
@@ -21,24 +19,15 @@ sjs="$SJS_HOST:$SJS_PORT"
 
 # remove any previously built versions of the JAR
 rm -f combined/target/scala-2.10/*.jar
+
 # Build the combined JAR
 ./sbt assembly
+
 # Get the name of the combined assembly. Using `head` when getting the
 # `jarpath` is a precaution. We only expect one JAR to be built, but
 # the other commands assume that $jarpath will be a single path
 # string.
 jarpath=`ls combined/target/scala-2.10/*.jar | head -n 1`
-jarname=$(basename $jarpath)
-appname="${jarname%.*}"
-
-# POST the JAR to Spark Job Server
-curl --data-binary "@$jarpath" "http://$sjs/jars/$appname"
-# Recreate the Spark context so that the new JAR is loaded.
-curl -X DELETE "http://$sjs/contexts/$context"
-# Issuing POST immediately after the DELETE fails with a "context
-# exits" error, so we sleep for a second.
-sleep 1
-curl -X POST "http://$sjs/contexts/$context"
 
 # The modeling project directory is shared into the VM at
 # /opt/modeling and the tile service loads the JAR from that path

--- a/tile/src/main/scala/TileService.scala
+++ b/tile/src/main/scala/TileService.scala
@@ -93,9 +93,7 @@ trait TileService extends HttpService
                    */
                   //layerMask(TileGetter.getMasksFromCatalog(implicitly, catalog, parsedLayerMask, extent, TileGetter.breaksZoom))
                 )
-                // TODO: use classBreaks() once https://github.com/geotrellis/geotrellis/issues/1462 is fixed
                 val breaks = masked.classBreaksExactInt(numBreaks)
-                println("------------------- Outer Breaks: " + breaks.mkString(","))
                 if (breaks.size > 0 && breaks(0) == NODATA) {
                   s"""{ "error" : "Unable to calculate breaks (NODATA)."} """ //failWith(new ModelingException("Unable to calculate breaks (NODATA)."))
                 } else {

--- a/tile/src/main/scala/TileServiceLogic.scala
+++ b/tile/src/main/scala/TileServiceLogic.scala
@@ -96,9 +96,7 @@ trait TileServiceLogic
       // Fetch the RDD if we don't already have it
       val rdd = if (rddOrNull != null) rddOrNull else
         getLayer(sc, catalog, layer, bounds)
-      // TODO: use classBreaks() once https://github.com/geotrellis/geotrellis/issues/1462 is fixed
       val breaks = rdd.classBreaksExactInt(normalizedBins)
-      println("------------------- Inner Breaks: " + breaks.mkString(","))
       val normalizer = ColorMap(breaks.zipWithIndex.toMap, ColorMap.Options(noDataColor = NODATA))
       normalizerCache += (key -> normalizer)
       normalizer


### PR DESCRIPTION
`classBreaksExactInt` can be slightly slower than `classBreaks` but it gives better results.

If you want to scratch your head about the differences, see the [breaks results](https://docs.google.com/a/azavea.com/spreadsheets/d/1ZK_zso1yF3Oa9JN1ZodS8BbF-b5NgBLuZrA2CmRCjxc).

Connects #114

Also update build script to exclude "summary" service, which we are no longer using.