### PR TITLE
Health check endpoint

### DIFF
--- a/scripts/endpoints.sh
+++ b/scripts/endpoints.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 echo
+echo ----------------- health-check
+curl http://localhost:8081/tile/gt/health-check
+
+echo
 echo ----------------- breaks
 curl -d 'bbox=-13193643.578247702,3977047.2455633273,-13100389.403739786,4039419.8606440313&layers=us-census-property-value-30m-epsg3857&weights=2&numBreaks=10&srid=3857' -X POST "http://localhost:8081/tile/gt/breaks"
 


### PR DESCRIPTION
Verifies that data can be loaded by checking that the data hub catalog contains some layers.

Testing:
```
curl http://localhost:8081/tile/gt/health-check
```
Should print "OK" if healthy.
Should return 503 if unhealthy.

Connects #125

Notes:
* I didn't find a way to check the status of the `SparkContext` -- just ways of checking the status of jobs running in it, which isn't what we want. Since it is created with a [top-level
call](https://github.com/OpenTreeMap/otm-modeling/blob/develop/tile/src/main/scala/TileService.scala#L26) I am optimistic that it will be ready when the service comes online.
* I didn't succeed in creating a situation where 503 was returned. I see 502 errors until the service is online, then OK.

Happy to extend this if there are further ideas on what would be useful. We could also give it a try as-is to see if it addresses OpenTreeMap/otm-cloud#307.