### PR TITLE
Re-enable land use masks when computing breaks

### DIFF
--- a/tile/src/main/scala/TileService.scala
+++ b/tile/src/main/scala/TileService.scala
@@ -83,19 +83,12 @@ trait TileService extends HttpService
                 val unmasked = weightedOverlayForBreaks(implicitly, catalog, layers, weights, extent)
                 val masked = applyMasks(
                   unmasked,
-                  polyMask(polys)
-                  /*
-                   TODO: Trying to use the land-use layer as a mask at
-                   a lower zoom levels generated "empty collection"
-                   exceptions. I suspect that the lower zoom versions
-                   have interpolated values that don't match the
-                   original, discrete values.
-                   */
-                  //layerMask(TileGetter.getMasksFromCatalog(implicitly, catalog, parsedLayerMask, extent, TileGetter.breaksZoom))
+                  polyMask(polys),
+                  layerMask(TileGetter.getMasksFromCatalog(implicitly, catalog, parsedLayerMask, extent, TileGetter.breaksZoom))
                 )
                 val breaks = masked.classBreaksExactInt(numBreaks)
                 if (breaks.size > 0 && breaks(0) == NODATA) {
-                  s"""{ "error" : "Unable to calculate breaks (NODATA)."} """ //failWith(new ModelingException("Unable to calculate breaks (NODATA)."))
+                  s"""{ "error" : "Unable to calculate breaks (NODATA)."} """
                 } else {
                   val breaksArray = breaks.mkString("[", ",", "]")
                   s"""{ "classBreaks" : $breaksArray }"""


### PR DESCRIPTION
Re-enabling land use masks when computing breaks seems to work fine, with no "empty collection" exceptions.

Connects OpenTreeMap/otm-addons#1253

Testing:

On a Philly-area treemap:
* Turn on "Percent Tree Canopy Coverage", High -> Low
* Filter Land Use to show only "Forest" (so we'd expect mostly dark blue values)
* Filter on Municipality > Abington (Montgomery)

Before these changes:

![image](https://cloud.githubusercontent.com/assets/2162993/20764602/e00a77ca-b6fc-11e6-8baa-b692eee7fcaa.png)

After these changes:

![image](https://cloud.githubusercontent.com/assets/2162993/20764987/87b1cc34-b6fe-11e6-9ad2-8c99c5bd090f.png)