### PR TITLE
When computing breaks, fetch only tiles which intersect polygon mask(s)

### DIFF
--- a/tile/src/main/scala/TileServiceLogic.scala
+++ b/tile/src/main/scala/TileServiceLogic.scala
@@ -46,15 +46,15 @@ trait TileServiceLogic
                                catalog: S3LayerReader,
                                layers:Seq[String],
                                weights:Seq[Int],
-                               bounds:Extent): TileLayerRDD[SpatialKey] =
+                               bounds:Extent,
+                               clippedBounds:Extent): TileLayerRDD[SpatialKey] =
   {
-    val rdds = layers.map { layer => getLayer(sc, catalog, layer, bounds) }
+    val rdds = layers.map { layer => getLayer(sc, catalog, layer, clippedBounds) }
     val resultMetadata = rdds.head.metadata.copy(cellType = IntConstantNoDataCellType)
     val weightedRdds = layers
       .zip(weights)
       .zip(rdds)
       .map { case ((layer, weight), rdd) =>
-        val rdd = getLayer(sc, catalog, layer, bounds)
         val normalizer = getNormalizer(sc, catalog, layer, rdd, bounds)
         val normalizedRdd =
           ContextRDD(rdd.color(normalizer), resultMetadata)

--- a/tile/src/main/scala/VectorHandling.scala
+++ b/tile/src/main/scala/VectorHandling.scala
@@ -42,4 +42,8 @@ trait VectorHandling {
       case _ => throw new ModelingException("SRID not supported.")
     }
   }
+
+  def clipExtentToExtentOfPolygons(extent: Extent, polys: Seq[Polygon]): Option[Extent] = {
+    extent intersection polys.map(_.envelope).reduce(_ combine _)
+  }
 }


### PR DESCRIPTION
The breaks endpoint only loads data within a specified extent. Clip that extent to the extent of any supplied polygon masks.

Note that we still use the full treemap extent as an index into our cache of normalized data.

There is also an opportunity to skip loading data if a tile is requested outside of the clipped extent. That would require converting z/x/y to an extent (probably not difficult if one knew the GeoTrellis incantations) and may not be crucial since typically a user would zoom in to their area of interest.

Also: remove redundant computation of `rdd` in `weightedOverlayForBreaks`.

Testing:

Without these changes:

1. Create a map centered on Philadelphia
1. Turn on Population Density
1. Mask to Municipality > Abington
1. `sudo tail -f /var/log/syslog | grep HIT &`
1. Change the weight of Population density so it will recompute the breaks. You should see 4 hits at zoom 8 for the breaks computation (followed by others for drawing tiles).
```
us-census-population-density-30m-epsg3857/8/14406 HTTP/1.1" 200 38999 "-" "aws-sdk-java/1.9.34 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/24.91-b01/1.7.0_91" "-" HIT
us-census-population-density-30m-epsg3857/8/14404 HTTP/1.1" 200 68816 "-" "aws-sdk-java/1.9.34 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/24.91-b01/1.7.0_91" "-" HIT
nlcd-zoomed/8/14406 HTTP/1.1" 200 79871 "-" "aws-sdk-java/1.9.34 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/24.91-b01/1.7.0_91" "-" HIT
nlcd-zoomed/8/14404 HTTP/1.1" 200 99690 "-" "aws-sdk-java/1.9.34 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/24.91-b01/1.7.0_91" "-" HIT
```

After rebuilding with these changes:

1. Change the weight of Population density so it will recompute the breaks. You should see just 2 hits at zoom 8 for the breaks computation (followed by others for drawing tiles).
```
us-census-population-density-30m-epsg3857/8/14404 HTTP/1.1" 200 68816 "-" "aws-sdk-java/1.9.34 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/24.91-b01/1.7.0_91" "-" HIT
nlcd-zoomed/8/14404 HTTP/1.1" 200 99690 "-" "aws-sdk-java/1.9.34 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/24.91-b01/1.7.0_91" "-" HIT
```

Connects #122