### PR TITLE
Don't crash if there are no polygon masks

### DIFF
--- a/tile/src/main/scala/VectorHandling.scala
+++ b/tile/src/main/scala/VectorHandling.scala
@@ -44,6 +44,10 @@ trait VectorHandling {
   }
 
   def clipExtentToExtentOfPolygons(extent: Extent, polys: Seq[Polygon]): Option[Extent] = {
-    extent intersection polys.map(_.envelope).reduce(_ combine _)
+    if (polys.isEmpty) {
+      Option(extent)
+    } else {
+      extent intersection polys.map(_.envelope).reduce(_ combine _)
+    }
   }
 }


### PR DESCRIPTION
Fixes a problem where turning on a prioritization variable without first setting a location mask caused an exception. 