### PR TITLE
Log exceptions in Rollbar

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -98,7 +98,13 @@ object OTMModelingBuild extends Build {
         "io.spray" %% "spray-json" % Version.sprayJson,
         "io.spray" %% "spray-can" % Version.spray,
         "org.apache.spark" %% "spark-core" % Version.spark % "provided",
-        "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided"
+        "org.apache.hadoop" % "hadoop-client" % Version.hadoop % "provided",
+        // Begin Rollbar
+        "com.storecove" %% "rollbar-scala" % "1.0",
+        "net.databinder.dispatch" %% "dispatch-core" % "0.11.2",
+        "org.json4s" %% "json4s-jackson" % "3.2.11",
+        "org.slf4j" % "slf4j-api" % "1.7.12"
+        // End Rollbar
       ),
 
       unmanagedResourceDirectories in Compile <+= baseDirectory / "data"

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Usage:
-# $ SJS_HOST=33.33.34.48 SJS_PORT=8090 ./scripts/rebuild.sh
+# scripts/rebuild.sh
 
 # 1. Build the modeling assembly JAR
 # 2. Copy the JAR to the project root, mounted in the vagrant VM

--- a/tile/src/main/resources/application.conf
+++ b/tile/src/main/resources/application.conf
@@ -1,6 +1,2 @@
-geotrellis.port = 8777
-geotrellis.host = "0.0.0.0"
-geotrellis.catalog = "data/catalog.json"
-server.static-path = "src/main/static"
-server.features-path = "data/features"
-
+tileService.port = 8777
+tileService.host = "0.0.0.0"

--- a/tile/src/main/scala/Rollbar.scala
+++ b/tile/src/main/scala/Rollbar.scala
@@ -1,0 +1,26 @@
+package org.opentreemap.modeling
+
+import com.storecove.rollbar.RollbarNotifierFactory
+import org.slf4j.MDC
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+trait Rollbar {
+
+  def postExceptionToRollbar(ex:Throwable): Unit = {
+    val accessToken = TileServiceConfig.rollbarAccessToken
+    val environment = TileServiceConfig.otmStackType
+    val notifier = RollbarNotifierFactory.getNotifier(accessToken, environment)
+    notifier.notify("ERROR", ex.getMessage, Some(ex), getMDC)
+  }
+
+  private def getMDC = {
+    val mdc = MDC.getCopyOfContextMap
+    if (mdc == null) {
+      mutable.Map.empty[String, String]
+    } else {
+      mapAsScalaMap(mdc)
+    }
+  }
+}

--- a/tile/src/main/scala/TileServiceConfig.scala
+++ b/tile/src/main/scala/TileServiceConfig.scala
@@ -20,8 +20,8 @@ object TileServiceConfig {
     Option(System.getenv(envVar)).getOrElse(config.getString(configKey))
   }
 
-  val host = stringFromEnvOrConfig("HOST", "geotrellis.host")
-  val port = intFromEnvOrConfig("PORT", "geotrellis.port")
-  val staticPath = stringFromEnvOrConfig("STATIC_PATH", "server.static-path")
-  val featuresPath = stringFromEnvOrConfig("FEATURES_PATH", "server.features-path")
+  val host = stringFromEnvOrConfig("HOST", "tileService.host")
+  val port = intFromEnvOrConfig("PORT", "tileService.port")
+  val rollbarAccessToken = System.getenv("ROLLBAR_SERVER_SIDE_ACCESS_TOKEN")
+  val otmStackType = System.getenv("OTM_STACK_TYPE")
 }


### PR DESCRIPTION
Also:
* Update `application.conf` (remove unused entries, rename others)
* Fix comment in `rebuild.sh` (host and port no longer needed)

Testing:

1. Check out OpenTreeMap/otm-cloud#325

1. `vagrant provision modeling`

1. Make the code throw an exception by inserting before [this line](https://github.com/OpenTreeMap/otm-modeling/blob/develop/tile/src/main/scala/TileService.scala#L82):
   ```scala
   throw new Exception("Test Rollbar from Scala")
   ```

1. `scripts/rebuild.sh`

1. Hit the `breaks` endpoint (e.g. by executing `scripts/endpoints.sh`)

You should see your exception logged in Rollbar, with a stack trace.

Connects #68