### PR TITLE
Make logs quieter, and post to Rollbar on startup

### DIFF
--- a/tile/src/main/scala/Rollbar.scala
+++ b/tile/src/main/scala/Rollbar.scala
@@ -8,11 +8,19 @@ import scala.collection.mutable
 
 trait Rollbar {
 
+  def postInfoToRollbar(message:String): Unit = {
+    postToRollbar("INFO", message, None)
+  }
+
   def postExceptionToRollbar(ex:Throwable): Unit = {
+    postToRollbar("ERROR", ex.getMessage, Some(ex))
+  }
+
+  private def postToRollbar(level:String, message:String, ex:Option[Throwable]): Unit = {
     val accessToken = TileServiceConfig.rollbarAccessToken
     val environment = TileServiceConfig.otmStackType
     val notifier = RollbarNotifierFactory.getNotifier(accessToken, environment)
-    notifier.notify("ERROR", ex.getMessage, Some(ex), getMDC)
+    notifier.notify(level, message, ex, getMDC)
   }
 
   private def getMDC = {

--- a/tile/src/main/scala/TileService.scala
+++ b/tile/src/main/scala/TileService.scala
@@ -27,6 +27,9 @@ trait TileService extends HttpService
 
   implicit val sparkContext = SparkUtils.createSparkContext("OTM Modeling Tile Service Context", new SparkConf())
 
+  sparkContext.setLogLevel("ERROR")
+  postInfoToRollbar("OpenTreeMap modeling tile service is starting")
+
   lazy val serviceRoute =
     handleExceptions(exceptionHandler) {
       healthCheckRoute ~


### PR DESCRIPTION
Testing:

1. `scripts/rebuild.sh`
1. Turn on a prioritization variable
1. In Rollbar dashboard, search for "modeling tile" - you should see an item labeled "OpenTreeMap modeling tile service is starting"
1. `vagrant ssh modeling`
1. `tail -99 /var/log/syslog` - log should look much cleaner (only `POST`s logged by nginx and `GET`s logged by the cacheing proxy.)

(The `breaks` endpoint still generates an extraneous INFO message about Akka dead letters. We should be able to mute it via log4j configuration if we want to.)

Connects #69
(...not really, but staging modeling servers are already successfully logging to Papertrail, and this PR reduces the noise.)