### PR TITLE
Update for standalone demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ Arguments:
 
 | Name       | Required? | Type    |  Description |
 |------------|-----------|---------|--------------|
-| bbox       | Yes       | String  | Bounding box projected as WebMercator. Format: `xmin,ymin,xmax,ymax`
+| bbox       | Yes       | String  | Bounding box (lat/long). Format: `xmin,ymin,xmax,ymax`
 | layers     | Yes       | String  | Layer names (comma delimited). Should match the source raster file names.
 | weights    | Yes       | String  | Layer weights (comma delimited integers) for corresponding layer. Negative weight inverts the tile value.
 | numBreaks  | Yes       | Int     | Number of result class breaks.
-| srid       | Yes       | Int     | Spatial Reference Identifier. Acceptable values are `3857` or `4326`.
 | threshold  |           | Int     | Exclude values lower than this value in class breaks calculation. (Default: `NODATA`)
 | polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons.
 | layerMask  |           | JSON    | Exclude values from result. Map of layer names to selected raster values. Format: `{ LayerName: [1, 2, 3], ...}`
@@ -83,11 +82,10 @@ Arguments:
 | width      | Yes       | Int     | *Used by Leaflet.*
 | height     | Yes       | Int     | *Used by Leaflet.*
 | palette    |           | String  | *Used by Leaflet.* Comma delimited list of hexadecimal values. (Default: `ff0000,ffff00,00ff00,0000ff`)
-| bbox       | Yes       | String  | Bounding box projected as WebMercator. Format: `xmin,ymin,xmax,ymax`
+| bbox       | Yes       | String  | Bounding box (lat/long). Format: `xmin,ymin,xmax,ymax`
 | layers     | Yes       | String  | Layer names (comma delimited). Should match the source raster file names.
 | weights    | Yes       | String  | Layer weights (comma delimited integers) for corresponding layer. Negative weight inverts the tile value.
 | breaks     | Yes       | String  | Class breaks (comma delimited integers)
-| srid       | Yes       | Int     | Spatial Reference Identifier. Acceptable values are `3857` or `4326`.
 | colorRamp  |           | String  | Color ramp name. (Default: `blue-to-red`)
 | threshold  |           | Int     | Exclude values lower than this value in class breaks calculation. (Default: `NODATA`)
 | polyMask   |           | GeoJSON | Exclude points not inside polygon. Should contain a FeatureCollection with Polygons or MultiPolygons.

--- a/scripts/endpoints.sh
+++ b/scripts/endpoints.sh
@@ -6,8 +6,8 @@ curl http://localhost:8081/tile/gt/health-check
 
 echo
 echo ----------------- breaks
-curl -d 'bbox=-13193643.578247702,3977047.2455633273,-13100389.403739786,4039419.8606440313&layers=us-census-property-value-30m-epsg3857&weights=2&numBreaks=10&srid=3857' -X POST "http://localhost:8081/tile/gt/breaks"
+curl "http://localhost:8081/tile/gt/breaks?bbox=-93.62626,44.63635,-92.72795,45.27205&layers=us-census-population-density-30m-epsg3857&weights=2&numBreaks=10"
 
 echo
 echo ----------------- tile
-curl -d 'bbox=-13193642.578247702,3977047.2455633273,-13100389.403739786,4039419.8606440313&layers=us-census-property-value-30m-epsg3857&weights=1&numBreaks=10&srid=3857&breaks=9,19,29,39,49,59,69,79,89,99&' -X POST "http://localhost:8081/tile/gt/tile/11/297/388.png" > ~/tile.png
+curl "http://localhost:8081/tile/gt/tile/10/124/183.png?bbox=-93.62626,44.63635,-92.72795,45.27205&layers=us-census-population-density-30m-epsg3857&weights=2&breaks=10,20,28,36,48,68,94,130,164,198" >tile.png


### PR DESCRIPTION
* `bbox` argument now lat/long -- convert to Web Mercator, remove `srid` parameter
* Allow cross-site references
  * Support `OPTIONS` HTTP method
  * Return access control headers
* Update health check route and `scripts/endpoints.sh` to work with these changes
* Leave `polyMask` parameter in place even though we're no longer exercising it. (See #149)

Testing:
* `endpoints.sh` should succeed
* http://localhost:6060/prioritization-demo should work

Connects OpenTreeMap/otm-addons#1507
Required by OpenTreeMap/otm-addons#1512