### PR TITLE
Simplify backend slightly by using Leaflet's zoomOffset

### DIFF
--- a/src/app-backend/tile/src/main/scala/TileService.scala
+++ b/src/app-backend/tile/src/main/scala/TileService.scala
@@ -198,16 +198,11 @@ trait TileService extends HttpService
                     4326
                   )
 
-                  // Our tiles are 512x512. Requesting Leaflet's z/x/y gives a "tile does not exist" error.
-                  // But requesting a zoom one level out works.
-                  // Apparently Leaflet and GeoTrellis have different ideas of TMS numbering for 512x512 tiles.
-                  val zoom = z - 1
-
-                  val unmasked = weightedOverlay(implicitly, catalog, tileReader, layers, weights, extent, zoom, x, y)
+                  val unmasked = weightedOverlay(implicitly, catalog, tileReader, layers, weights, extent, z, x, y)
                   val masked = applyTileMasks(
                     unmasked,
-                    polyTileMask(polys, zoom, x, y),
-                    layerTileMask(TileGetter.getMaskTiles(implicitly, catalog, tileReader, parsedLayerMask, zoom, x, y)),
+                    polyTileMask(polys, z, x, y),
+                    layerTileMask(TileGetter.getMaskTiles(implicitly, catalog, tileReader, parsedLayerMask, z, x, y)),
                     thresholdTileMask(threshold)
                   )
 

--- a/src/app-frontend/js/modeling/prioritization.js
+++ b/src/app-frontend/js/modeling/prioritization.js
@@ -264,7 +264,8 @@ function updatePriorityLayer(map, breaks) {
         if (!_priorityLayer) {
             var options = {
                 bounds: _bounds,
-                tileSize: 512
+                tileSize: 512,
+                zoomOffset: -1  // https://github.com/locationtech/geotrellis/issues/1550
             };
             _priorityLayer = new L.TileLayer(url, options);
             _priorityLayer.on('loading', function() {


### PR DESCRIPTION
Connects #123

Testing:
* Tiles should display as before (once you've rebuilt your VM with Hector's changes)
* Note that (once you've rebuilt your VM with Hector's changes) building the backend outside of the VM (`./sbt assembly`) is still much faster than building inside the VM.