### PR TITLE
Add geocoder and set prioritization bounds based on geocode result

### DIFF
--- a/src/app-frontend/assets/css/sass/main.scss
+++ b/src/app-frontend/assets/css/sass/main.scss
@@ -6,6 +6,7 @@
 @import "../vendor/bootstrap-slider";
 @import "../vendor/fontello";
 @import "../vendor/leaflet";
+@import "../vendor/toastr";
 
 // Modules
 @import "modules/checkboxes";

--- a/src/app-frontend/assets/css/sass/partials/_modeling.scss
+++ b/src/app-frontend/assets/css/sass/partials/_modeling.scss
@@ -56,6 +56,23 @@ $blue-to-red: #2791c3 10%,
             right: 0;
             left: 350px;
 
+            .geocode {
+                position: absolute;
+                top: 10px;
+                left: 52px;
+                z-index: 1000;
+                width: 250px;
+
+                input {
+                    padding-left: 32px;
+                    border: 2px solid rgba(0, 0, 0, 0.2);
+                }
+
+                span.search {
+                    left: 0px;
+                }
+            }
+
             .options {
                 position: absolute;
                 top: 16px;
@@ -135,7 +152,7 @@ $blue-to-red: #2791c3 10%,
         }
     }
 
-    .leaflet-loading-control { 
+    .leaflet-loading-control {
         background: #fff;
         padding: 5px 10px;
         font-size: 12pt;

--- a/src/app-frontend/assets/css/vendor/toastr.css
+++ b/src/app-frontend/assets/css/vendor/toastr.css
@@ -1,0 +1,228 @@
+.toast-title {
+  font-weight: bold;
+}
+.toast-message {
+  -ms-word-wrap: break-word;
+  word-wrap: break-word;
+}
+.toast-message a,
+.toast-message label {
+  color: #FFFFFF;
+}
+.toast-message a:hover {
+  color: #CCCCCC;
+  text-decoration: none;
+}
+.toast-close-button {
+  position: relative;
+  right: -0.3em;
+  top: -0.3em;
+  float: right;
+  font-size: 20px;
+  font-weight: bold;
+  color: #FFFFFF;
+  -webkit-text-shadow: 0 1px 0 #ffffff;
+  text-shadow: 0 1px 0 #ffffff;
+  opacity: 0.8;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
+  filter: alpha(opacity=80);
+  line-height: 1;
+}
+.toast-close-button:hover,
+.toast-close-button:focus {
+  color: #000000;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.4;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
+  filter: alpha(opacity=40);
+}
+.rtl .toast-close-button {
+  left: -0.3em;
+  float: left;
+  right: 0.3em;
+}
+/*Additional properties for button version
+ iOS requires the button element instead of an anchor tag.
+ If you want the anchor version, it requires `href="#"`.*/
+button.toast-close-button {
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  -webkit-appearance: none;
+}
+.toast-top-center {
+  top: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-bottom-center {
+  bottom: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-top-full-width {
+  top: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-bottom-full-width {
+  bottom: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-top-left {
+  top: 12px;
+  left: 12px;
+}
+.toast-top-right {
+  top: 12px;
+  right: 12px;
+}
+.toast-bottom-right {
+  right: 12px;
+  bottom: 12px;
+}
+.toast-bottom-left {
+  bottom: 12px;
+  left: 12px;
+}
+#toast-container {
+  position: fixed;
+  z-index: 999999;
+  pointer-events: none;
+  /*overrides*/
+}
+#toast-container * {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+#toast-container > div {
+  position: relative;
+  pointer-events: auto;
+  overflow: hidden;
+  margin: 0 0 6px;
+  padding: 15px 15px 15px 50px;
+  width: 300px;
+  -moz-border-radius: 3px 3px 3px 3px;
+  -webkit-border-radius: 3px 3px 3px 3px;
+  border-radius: 3px 3px 3px 3px;
+  background-position: 15px center;
+  background-repeat: no-repeat;
+  -moz-box-shadow: 0 0 12px #999999;
+  -webkit-box-shadow: 0 0 12px #999999;
+  box-shadow: 0 0 12px #999999;
+  color: #FFFFFF;
+  opacity: 0.8;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
+  filter: alpha(opacity=80);
+}
+#toast-container > div.rtl {
+  direction: rtl;
+  padding: 15px 50px 15px 15px;
+  background-position: right 15px center;
+}
+#toast-container > div:hover {
+  -moz-box-shadow: 0 0 12px #000000;
+  -webkit-box-shadow: 0 0 12px #000000;
+  box-shadow: 0 0 12px #000000;
+  opacity: 1;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+  filter: alpha(opacity=100);
+  cursor: pointer;
+}
+#toast-container > .toast-info {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGwSURBVEhLtZa9SgNBEMc9sUxxRcoUKSzSWIhXpFMhhYWFhaBg4yPYiWCXZxBLERsLRS3EQkEfwCKdjWJAwSKCgoKCcudv4O5YLrt7EzgXhiU3/4+b2ckmwVjJSpKkQ6wAi4gwhT+z3wRBcEz0yjSseUTrcRyfsHsXmD0AmbHOC9Ii8VImnuXBPglHpQ5wwSVM7sNnTG7Za4JwDdCjxyAiH3nyA2mtaTJufiDZ5dCaqlItILh1NHatfN5skvjx9Z38m69CgzuXmZgVrPIGE763Jx9qKsRozWYw6xOHdER+nn2KkO+Bb+UV5CBN6WC6QtBgbRVozrahAbmm6HtUsgtPC19tFdxXZYBOfkbmFJ1VaHA1VAHjd0pp70oTZzvR+EVrx2Ygfdsq6eu55BHYR8hlcki+n+kERUFG8BrA0BwjeAv2M8WLQBtcy+SD6fNsmnB3AlBLrgTtVW1c2QN4bVWLATaIS60J2Du5y1TiJgjSBvFVZgTmwCU+dAZFoPxGEEs8nyHC9Bwe2GvEJv2WXZb0vjdyFT4Cxk3e/kIqlOGoVLwwPevpYHT+00T+hWwXDf4AJAOUqWcDhbwAAAAASUVORK5CYII=") !important;
+}
+#toast-container > .toast-error {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAHOSURBVEhLrZa/SgNBEMZzh0WKCClSCKaIYOED+AAKeQQLG8HWztLCImBrYadgIdY+gIKNYkBFSwu7CAoqCgkkoGBI/E28PdbLZmeDLgzZzcx83/zZ2SSXC1j9fr+I1Hq93g2yxH4iwM1vkoBWAdxCmpzTxfkN2RcyZNaHFIkSo10+8kgxkXIURV5HGxTmFuc75B2RfQkpxHG8aAgaAFa0tAHqYFfQ7Iwe2yhODk8+J4C7yAoRTWI3w/4klGRgR4lO7Rpn9+gvMyWp+uxFh8+H+ARlgN1nJuJuQAYvNkEnwGFck18Er4q3egEc/oO+mhLdKgRyhdNFiacC0rlOCbhNVz4H9FnAYgDBvU3QIioZlJFLJtsoHYRDfiZoUyIxqCtRpVlANq0EU4dApjrtgezPFad5S19Wgjkc0hNVnuF4HjVA6C7QrSIbylB+oZe3aHgBsqlNqKYH48jXyJKMuAbiyVJ8KzaB3eRc0pg9VwQ4niFryI68qiOi3AbjwdsfnAtk0bCjTLJKr6mrD9g8iq/S/B81hguOMlQTnVyG40wAcjnmgsCNESDrjme7wfftP4P7SP4N3CJZdvzoNyGq2c/HWOXJGsvVg+RA/k2MC/wN6I2YA2Pt8GkAAAAASUVORK5CYII=") !important;
+}
+#toast-container > .toast-success {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADsSURBVEhLY2AYBfQMgf///3P8+/evAIgvA/FsIF+BavYDDWMBGroaSMMBiE8VC7AZDrIFaMFnii3AZTjUgsUUWUDA8OdAH6iQbQEhw4HyGsPEcKBXBIC4ARhex4G4BsjmweU1soIFaGg/WtoFZRIZdEvIMhxkCCjXIVsATV6gFGACs4Rsw0EGgIIH3QJYJgHSARQZDrWAB+jawzgs+Q2UO49D7jnRSRGoEFRILcdmEMWGI0cm0JJ2QpYA1RDvcmzJEWhABhD/pqrL0S0CWuABKgnRki9lLseS7g2AlqwHWQSKH4oKLrILpRGhEQCw2LiRUIa4lwAAAABJRU5ErkJggg==") !important;
+}
+#toast-container > .toast-warning {
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGYSURBVEhL5ZSvTsNQFMbXZGICMYGYmJhAQIJAICYQPAACiSDB8AiICQQJT4CqQEwgJvYASAQCiZiYmJhAIBATCARJy+9rTsldd8sKu1M0+dLb057v6/lbq/2rK0mS/TRNj9cWNAKPYIJII7gIxCcQ51cvqID+GIEX8ASG4B1bK5gIZFeQfoJdEXOfgX4QAQg7kH2A65yQ87lyxb27sggkAzAuFhbbg1K2kgCkB1bVwyIR9m2L7PRPIhDUIXgGtyKw575yz3lTNs6X4JXnjV+LKM/m3MydnTbtOKIjtz6VhCBq4vSm3ncdrD2lk0VgUXSVKjVDJXJzijW1RQdsU7F77He8u68koNZTz8Oz5yGa6J3H3lZ0xYgXBK2QymlWWA+RWnYhskLBv2vmE+hBMCtbA7KX5drWyRT/2JsqZ2IvfB9Y4bWDNMFbJRFmC9E74SoS0CqulwjkC0+5bpcV1CZ8NMej4pjy0U+doDQsGyo1hzVJttIjhQ7GnBtRFN1UarUlH8F3xict+HY07rEzoUGPlWcjRFRr4/gChZgc3ZL2d8oAAAAASUVORK5CYII=") !important;
+}
+#toast-container.toast-top-center > div,
+#toast-container.toast-bottom-center > div {
+  width: 300px;
+  margin-left: auto;
+  margin-right: auto;
+}
+#toast-container.toast-top-full-width > div,
+#toast-container.toast-bottom-full-width > div {
+  width: 96%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.toast {
+  background-color: #030303;
+}
+.toast-success {
+  background-color: #51A351;
+}
+.toast-error {
+  background-color: #BD362F;
+}
+.toast-info {
+  background-color: #2F96B4;
+}
+.toast-warning {
+  background-color: #F89406;
+}
+.toast-progress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 4px;
+  background-color: #000000;
+  opacity: 0.4;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
+  filter: alpha(opacity=40);
+}
+/*Responsive Design*/
+@media all and (max-width: 240px) {
+  #toast-container > div {
+    padding: 8px 8px 8px 50px;
+    width: 11em;
+  }
+  #toast-container > div.rtl {
+    padding: 8px 50px 8px 8px;
+  }
+  #toast-container .toast-close-button {
+    right: -0.2em;
+    top: -0.2em;
+  }
+  #toast-container .rtl .toast-close-button {
+    left: -0.2em;
+    right: 0.2em;
+  }
+}
+@media all and (min-width: 241px) and (max-width: 480px) {
+  #toast-container > div {
+    padding: 8px 8px 8px 50px;
+    width: 18em;
+  }
+  #toast-container > div.rtl {
+    padding: 8px 50px 8px 8px;
+  }
+  #toast-container .toast-close-button {
+    right: -0.2em;
+    top: -0.2em;
+  }
+  #toast-container .rtl .toast-close-button {
+    left: -0.2em;
+    right: 0.2em;
+  }
+}
+@media all and (min-width: 481px) and (max-width: 768px) {
+  #toast-container > div {
+    padding: 15px 15px 15px 50px;
+    width: 25em;
+  }
+  #toast-container > div.rtl {
+    padding: 15px 50px 15px 15px;
+  }
+}

--- a/src/app-frontend/js/modeling/geocoder.js
+++ b/src/app-frontend/js/modeling/geocoder.js
@@ -1,0 +1,23 @@
+var Bacon = require('baconjs');
+
+function createGeocodeStream(addressStream) {
+    var geocoder = new google.maps.Geocoder(),
+        geocodeBus = new Bacon.Bus(),
+        prepareAddress = function (address) { return {'address': address}; },
+        geocode = function (searchValue) {
+            geocoder.geocode(searchValue, function(results, status) {
+                if (status === 'OK') {
+                    geocodeBus.push(results[0].geometry.location.toJSON());
+                } else {
+                    geocodeBus.error('Failed to find location. ' + status);
+                }
+            });
+        };
+    addressStream.map(prepareAddress).onValue(geocode);
+    return geocodeBus.toEventStream();
+}
+
+
+module.exports = {
+    createGeocodeStream: createGeocodeStream
+};

--- a/src/app-frontend/js/modeling/geocoder.js
+++ b/src/app-frontend/js/modeling/geocoder.js
@@ -2,6 +2,16 @@ var $ = require('jquery'),
     Bacon = require('baconjs'),
     BU = require('./baconUtils.js');
 
+// Failure status codes described here:
+// https://developers.google.com/maps/documentation/geocoding/intro
+var failureMessages = {
+    'ZERO_RESULTS': 'Could not find any matching locations.',
+    'OVER_QUERY_LIMIT': 'There are too many location searches right now.',
+    'REQUEST_DENIED': 'There was a problem finding the location.',
+    'INVALID_REQUEST': 'There was a problem finding the location.',
+    'UNKNOWN_ERROR': 'An unknown problem prevented finding the location.'
+};
+
 function searchBoxStream(inputSelector) {
     return  $(inputSelector)
         .asEventStream('keyup')
@@ -35,7 +45,11 @@ function createGeocodeStream(textbox) {
                 if (status === 'OK') {
                     geocodeBus.push(results[0].geometry.location.toJSON());
                 } else {
-                    geocodeBus.error('Failed to find location. ' + status);
+                    if (failureMessages[status]) {
+                        geocodeBus.error(failureMessages[status]);
+                    } else {
+                        geocodeBus.error('Failed to find location.');
+                    }
                 }
             });
         };

--- a/src/app-frontend/js/modeling/modeling.js
+++ b/src/app-frontend/js/modeling/modeling.js
@@ -2,22 +2,18 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
-    BU = require('./baconUtils.js'),
     prioritization = require('./prioritization.js'),
     template = require('./template.js'),
     geocoder = require('./geocoder.js');
+
+var dom = {
+    geocode: '#geocode'
+}
 
 require("../../assets/css/sass/main.scss");
 
 require('es6-promise').polyfill(); // https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant
 require('leaflet.gridlayer.googlemutant');
-
-function searchBoxStream(inputSelector) {
-    return  $(inputSelector)
-        .asEventStream('keyup')
-        .map(function () { return $(inputSelector).val();})
-        .sampledBy(BU.enterOrClickEventStream({inputs: inputSelector}));
-}
 
 function centerToBounds(center) {
     // 10,000 meters is a roughly city size boundary
@@ -51,10 +47,8 @@ function init() {
     if (query.center) {
         bounds = centerToBounds(L.latLng(JSON.parse('[' + query.center + ']')));
     }
-
-    var addressStream = searchBoxStream('#geocode');
-    var centerStream = geocoder.createGeocodeStream(addressStream);
-
+ 
+    var centerStream = geocoder.createGeocodeStream(dom.geocode);
     centerStream.map(centerToParam).onValue(pushCenterParamToUrl);
 
     var boundsStream = centerStream.map(centerToBounds);

--- a/src/app-frontend/js/modeling/modeling.js
+++ b/src/app-frontend/js/modeling/modeling.js
@@ -2,13 +2,41 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
+    BU = require('./baconUtils.js'),
     prioritization = require('./prioritization.js'),
-    template = require('./template.js');
+    template = require('./template.js'),
+    geocoder = require('./geocoder.js');
 
 require("../../assets/css/sass/main.scss");
 
 require('es6-promise').polyfill(); // https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant
 require('leaflet.gridlayer.googlemutant');
+
+function searchBoxStream(inputSelector) {
+    return  $(inputSelector)
+        .asEventStream('keyup')
+        .map(function () { return $(inputSelector).val();})
+        .sampledBy(BU.enterOrClickEventStream({inputs: inputSelector}));
+}
+
+function centerToBounds(center) {
+    // 10,000 meters is a roughly city size boundary
+    return L.latLng(center).toBounds(5000);
+}
+
+function queryStringObject() {
+    var params = location.search.substring(1);
+    if (params.trim() !== '') {
+        try {
+            return JSON.parse('{"' + decodeURIComponent(params).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g,'":"') + '"}');
+        } catch (e) {
+            console.log(e);
+            return {};
+        }
+    } else {
+        return {};
+    }
+}
 
 function init() {
     if (window.location.hostname == "localhost"){
@@ -16,13 +44,26 @@ function init() {
     } else {
         var urlPrefix = 'https://' + window.location.hostname + '/tile/gt/';
     }
+
     // Minneapolis / St Paul
     var bounds = L.latLngBounds([44.63635, -93.62626], [45.27205, -92.72795]);
+    var query = queryStringObject();
+    if (query.center) {
+        bounds = centerToBounds(L.latLng(JSON.parse('[' + query.center + ']')));
+    }
+
+    var addressStream = searchBoxStream('#geocode');
+    var centerStream = geocoder.createGeocodeStream(addressStream);
+
+    centerStream.map(centerToParam).onValue(pushCenterParamToUrl);
+
+    var boundsStream = centerStream.map(centerToBounds);
 
     expandTemplates();
     prioritization.init({
-        map: createMap(bounds),
+        map: createMap(bounds, boundsStream),
         instanceBounds: bounds,
+        boundsStream: boundsStream,
         urls: {
             breaksUrl: urlPrefix + 'breaks',
             tileUrl: urlPrefix + 'tile/{z}/{x}/{y}.png'
@@ -40,11 +81,25 @@ function expandTemplates() {
     }));
 }
 
-function createMap(bounds) {
+function centerToParam(center) {
+    var latLng = L.latLng(center);
+    return '' + latLng.lat + ',' + latLng.lng;
+}
+
+function pushCenterParamToUrl(center) {
+    var baseUrl = [location.protocol, '//', location.host, location.pathname].join('');
+    if (window.history) {
+        window.history.pushState(null, document.title, [baseUrl, '?', $.param({center: center}), location.hash].join(''));
+    }
+}
+
+function createMap(bounds, boundsStream) {
     var map = L.map('map'),
         baseMapPaneName = 'base-map';
     map.createPane(baseMapPaneName);  // CSS class 'leaflet-base-map-pane'
     map.fitBounds(bounds);
+
+    boundsStream.onValue(map.fitBounds.bind(map));
 
     var basemapMapping = {
             'Streets':   makeBaseLayer('roadmap'),

--- a/src/app-frontend/js/modeling/modeling.js
+++ b/src/app-frontend/js/modeling/modeling.js
@@ -2,6 +2,7 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
+    toastr = require('toastr'),
     prioritization = require('./prioritization.js'),
     template = require('./template.js'),
     geocoder = require('./geocoder.js');
@@ -47,9 +48,12 @@ function init() {
     if (query.center) {
         bounds = centerToBounds(L.latLng(JSON.parse('[' + query.center + ']')));
     }
- 
+
     var centerStream = geocoder.createGeocodeStream(dom.geocode);
     centerStream.map(centerToParam).onValue(pushCenterParamToUrl);
+    centerStream.onError(function (message) {
+        toastr.error(message);
+    });
 
     var boundsStream = centerStream.map(centerToBounds);
 

--- a/src/app-frontend/js/vendor/toastr.js
+++ b/src/app-frontend/js/vendor/toastr.js
@@ -1,0 +1,476 @@
+/*
+ * Toastr
+ * Copyright 2012-2015
+ * Authors: John Papa, Hans Fjällemark, and Tim Ferrell.
+ * All Rights Reserved.
+ * Use, reproduction, distribution, and modification of this code is subject to the terms and
+ * conditions of the MIT license, available at http://www.opensource.org/licenses/mit-license.php
+ *
+ * ARIA Support: Greta Krafsig
+ *
+ * Project: https://github.com/CodeSeven/toastr
+ */
+/* global define */
+(function (define) {
+    define(['jquery'], function ($) {
+        return (function () {
+            var $container;
+            var listener;
+            var toastId = 0;
+            var toastType = {
+                error: 'error',
+                info: 'info',
+                success: 'success',
+                warning: 'warning'
+            };
+
+            var toastr = {
+                clear: clear,
+                remove: remove,
+                error: error,
+                getContainer: getContainer,
+                info: info,
+                options: {},
+                subscribe: subscribe,
+                success: success,
+                version: '2.1.3',
+                warning: warning
+            };
+
+            var previousToast;
+
+            return toastr;
+
+            ////////////////
+
+            function error(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.error,
+                    iconClass: getOptions().iconClasses.error,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
+
+            function getContainer(options, create) {
+                if (!options) { options = getOptions(); }
+                $container = $('#' + options.containerId);
+                if ($container.length) {
+                    return $container;
+                }
+                if (create) {
+                    $container = createContainer(options);
+                }
+                return $container;
+            }
+
+            function info(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.info,
+                    iconClass: getOptions().iconClasses.info,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
+
+            function subscribe(callback) {
+                listener = callback;
+            }
+
+            function success(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.success,
+                    iconClass: getOptions().iconClasses.success,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
+
+            function warning(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.warning,
+                    iconClass: getOptions().iconClasses.warning,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
+
+            function clear($toastElement, clearOptions) {
+                var options = getOptions();
+                if (!$container) { getContainer(options); }
+                if (!clearToast($toastElement, options, clearOptions)) {
+                    clearContainer(options);
+                }
+            }
+
+            function remove($toastElement) {
+                var options = getOptions();
+                if (!$container) { getContainer(options); }
+                if ($toastElement && $(':focus', $toastElement).length === 0) {
+                    removeToast($toastElement);
+                    return;
+                }
+                if ($container.children().length) {
+                    $container.remove();
+                }
+            }
+
+            // internal functions
+
+            function clearContainer (options) {
+                var toastsToClear = $container.children();
+                for (var i = toastsToClear.length - 1; i >= 0; i--) {
+                    clearToast($(toastsToClear[i]), options);
+                }
+            }
+
+            function clearToast ($toastElement, options, clearOptions) {
+                var force = clearOptions && clearOptions.force ? clearOptions.force : false;
+                if ($toastElement && (force || $(':focus', $toastElement).length === 0)) {
+                    $toastElement[options.hideMethod]({
+                        duration: options.hideDuration,
+                        easing: options.hideEasing,
+                        complete: function () { removeToast($toastElement); }
+                    });
+                    return true;
+                }
+                return false;
+            }
+
+            function createContainer(options) {
+                $container = $('<div/>')
+                    .attr('id', options.containerId)
+                    .addClass(options.positionClass);
+
+                $container.appendTo($(options.target));
+                return $container;
+            }
+
+            function getDefaults() {
+                return {
+                    tapToDismiss: true,
+                    toastClass: 'toast',
+                    containerId: 'toast-container',
+                    debug: false,
+
+                    showMethod: 'fadeIn', //fadeIn, slideDown, and show are built into jQuery
+                    showDuration: 300,
+                    showEasing: 'swing', //swing and linear are built into jQuery
+                    onShown: undefined,
+                    hideMethod: 'fadeOut',
+                    hideDuration: 1000,
+                    hideEasing: 'swing',
+                    onHidden: undefined,
+                    closeMethod: false,
+                    closeDuration: false,
+                    closeEasing: false,
+                    closeOnHover: true,
+
+                    extendedTimeOut: 1000,
+                    iconClasses: {
+                        error: 'toast-error',
+                        info: 'toast-info',
+                        success: 'toast-success',
+                        warning: 'toast-warning'
+                    },
+                    iconClass: 'toast-info',
+                    positionClass: 'toast-top-right',
+                    timeOut: 5000, // Set timeOut and extendedTimeOut to 0 to make it sticky
+                    titleClass: 'toast-title',
+                    messageClass: 'toast-message',
+                    escapeHtml: false,
+                    target: 'body',
+                    closeHtml: '<button type="button">&times;</button>',
+                    closeClass: 'toast-close-button',
+                    newestOnTop: true,
+                    preventDuplicates: false,
+                    progressBar: false,
+                    progressClass: 'toast-progress',
+                    rtl: false
+                };
+            }
+
+            function publish(args) {
+                if (!listener) { return; }
+                listener(args);
+            }
+
+            function notify(map) {
+                var options = getOptions();
+                var iconClass = map.iconClass || options.iconClass;
+
+                if (typeof (map.optionsOverride) !== 'undefined') {
+                    options = $.extend(options, map.optionsOverride);
+                    iconClass = map.optionsOverride.iconClass || iconClass;
+                }
+
+                if (shouldExit(options, map)) { return; }
+
+                toastId++;
+
+                $container = getContainer(options, true);
+
+                var intervalId = null;
+                var $toastElement = $('<div/>');
+                var $titleElement = $('<div/>');
+                var $messageElement = $('<div/>');
+                var $progressElement = $('<div/>');
+                var $closeElement = $(options.closeHtml);
+                var progressBar = {
+                    intervalId: null,
+                    hideEta: null,
+                    maxHideTime: null
+                };
+                var response = {
+                    toastId: toastId,
+                    state: 'visible',
+                    startTime: new Date(),
+                    options: options,
+                    map: map
+                };
+
+                personalizeToast();
+
+                displayToast();
+
+                handleEvents();
+
+                publish(response);
+
+                if (options.debug && console) {
+                    console.log(response);
+                }
+
+                return $toastElement;
+
+                function escapeHtml(source) {
+                    if (source == null) {
+                        source = '';
+                    }
+
+                    return source
+                        .replace(/&/g, '&amp;')
+                        .replace(/"/g, '&quot;')
+                        .replace(/'/g, '&#39;')
+                        .replace(/</g, '&lt;')
+                        .replace(/>/g, '&gt;');
+                }
+
+                function personalizeToast() {
+                    setIcon();
+                    setTitle();
+                    setMessage();
+                    setCloseButton();
+                    setProgressBar();
+                    setRTL();
+                    setSequence();
+                    setAria();
+                }
+
+                function setAria() {
+                    var ariaValue = '';
+                    switch (map.iconClass) {
+                        case 'toast-success':
+                        case 'toast-info':
+                            ariaValue =  'polite';
+                            break;
+                        default:
+                            ariaValue = 'assertive';
+                    }
+                    $toastElement.attr('aria-live', ariaValue);
+                }
+
+                function handleEvents() {
+                    if (options.closeOnHover) {
+                        $toastElement.hover(stickAround, delayedHideToast);
+                    }
+
+                    if (!options.onclick && options.tapToDismiss) {
+                        $toastElement.click(hideToast);
+                    }
+
+                    if (options.closeButton && $closeElement) {
+                        $closeElement.click(function (event) {
+                            if (event.stopPropagation) {
+                                event.stopPropagation();
+                            } else if (event.cancelBubble !== undefined && event.cancelBubble !== true) {
+                                event.cancelBubble = true;
+                            }
+
+                            if (options.onCloseClick) {
+                                options.onCloseClick(event);
+                            }
+
+                            hideToast(true);
+                        });
+                    }
+
+                    if (options.onclick) {
+                        $toastElement.click(function (event) {
+                            options.onclick(event);
+                            hideToast();
+                        });
+                    }
+                }
+
+                function displayToast() {
+                    $toastElement.hide();
+
+                    $toastElement[options.showMethod](
+                        {duration: options.showDuration, easing: options.showEasing, complete: options.onShown}
+                    );
+
+                    if (options.timeOut > 0) {
+                        intervalId = setTimeout(hideToast, options.timeOut);
+                        progressBar.maxHideTime = parseFloat(options.timeOut);
+                        progressBar.hideEta = new Date().getTime() + progressBar.maxHideTime;
+                        if (options.progressBar) {
+                            progressBar.intervalId = setInterval(updateProgress, 10);
+                        }
+                    }
+                }
+
+                function setIcon() {
+                    if (map.iconClass) {
+                        $toastElement.addClass(options.toastClass).addClass(iconClass);
+                    }
+                }
+
+                function setSequence() {
+                    if (options.newestOnTop) {
+                        $container.prepend($toastElement);
+                    } else {
+                        $container.append($toastElement);
+                    }
+                }
+
+                function setTitle() {
+                    if (map.title) {
+                        var suffix = map.title;
+                        if (options.escapeHtml) {
+                            suffix = escapeHtml(map.title);
+                        }
+                        $titleElement.append(suffix).addClass(options.titleClass);
+                        $toastElement.append($titleElement);
+                    }
+                }
+
+                function setMessage() {
+                    if (map.message) {
+                        var suffix = map.message;
+                        if (options.escapeHtml) {
+                            suffix = escapeHtml(map.message);
+                        }
+                        $messageElement.append(suffix).addClass(options.messageClass);
+                        $toastElement.append($messageElement);
+                    }
+                }
+
+                function setCloseButton() {
+                    if (options.closeButton) {
+                        $closeElement.addClass(options.closeClass).attr('role', 'button');
+                        $toastElement.prepend($closeElement);
+                    }
+                }
+
+                function setProgressBar() {
+                    if (options.progressBar) {
+                        $progressElement.addClass(options.progressClass);
+                        $toastElement.prepend($progressElement);
+                    }
+                }
+
+                function setRTL() {
+                    if (options.rtl) {
+                        $toastElement.addClass('rtl');
+                    }
+                }
+
+                function shouldExit(options, map) {
+                    if (options.preventDuplicates) {
+                        if (map.message === previousToast) {
+                            return true;
+                        } else {
+                            previousToast = map.message;
+                        }
+                    }
+                    return false;
+                }
+
+                function hideToast(override) {
+                    var method = override && options.closeMethod !== false ? options.closeMethod : options.hideMethod;
+                    var duration = override && options.closeDuration !== false ?
+                        options.closeDuration : options.hideDuration;
+                    var easing = override && options.closeEasing !== false ? options.closeEasing : options.hideEasing;
+                    if ($(':focus', $toastElement).length && !override) {
+                        return;
+                    }
+                    clearTimeout(progressBar.intervalId);
+                    return $toastElement[method]({
+                        duration: duration,
+                        easing: easing,
+                        complete: function () {
+                            removeToast($toastElement);
+                            clearTimeout(intervalId);
+                            if (options.onHidden && response.state !== 'hidden') {
+                                options.onHidden();
+                            }
+                            response.state = 'hidden';
+                            response.endTime = new Date();
+                            publish(response);
+                        }
+                    });
+                }
+
+                function delayedHideToast() {
+                    if (options.timeOut > 0 || options.extendedTimeOut > 0) {
+                        intervalId = setTimeout(hideToast, options.extendedTimeOut);
+                        progressBar.maxHideTime = parseFloat(options.extendedTimeOut);
+                        progressBar.hideEta = new Date().getTime() + progressBar.maxHideTime;
+                    }
+                }
+
+                function stickAround() {
+                    clearTimeout(intervalId);
+                    progressBar.hideEta = 0;
+                    $toastElement.stop(true, true)[options.showMethod](
+                        {duration: options.showDuration, easing: options.showEasing}
+                    );
+                }
+
+                function updateProgress() {
+                    var percentage = ((progressBar.hideEta - (new Date().getTime())) / progressBar.maxHideTime) * 100;
+                    $progressElement.width(percentage + '%');
+                }
+            }
+
+            function getOptions() {
+                return $.extend({}, getDefaults(), toastr.options);
+            }
+
+            function removeToast($toastElement) {
+                if (!$container) { $container = getContainer(); }
+                if ($toastElement.is(':visible')) {
+                    return;
+                }
+                $toastElement.remove();
+                $toastElement = null;
+                if ($container.children().length === 0) {
+                    $container.remove();
+                    previousToast = undefined;
+                }
+            }
+
+        })();
+    });
+}(typeof define === 'function' && define.amd ? define : function (deps, factory) {
+    if (typeof module !== 'undefined' && module.exports) { //Node
+        module.exports = factory(require('jquery'));
+    } else {
+        window.toastr = factory(window.jQuery);
+    }
+}));

--- a/src/app-frontend/template.handlebars
+++ b/src/app-frontend/template.handlebars
@@ -258,4 +258,4 @@
     </div>
 </script>
 
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCxp4_gTJHlsFnBHcDlo0Q-qqWPTZitnT8"></script>
+<script src="https://maps.googleapis.com/maps/api/js?libraries=places&key=AIzaSyCxp4_gTJHlsFnBHcDlo0Q-qqWPTZitnT8"></script>

--- a/src/app-frontend/template.handlebars
+++ b/src/app-frontend/template.handlebars
@@ -96,6 +96,10 @@
                 <small class="pull-left">0%</small><small class="pull-right">100%</small>
             </div>
         </div>
+        <div class="geocode form-group">
+            <input class="form-control" id="geocode" type="text" placeholder="Jump to a location" name="geocode" value="" />
+            <span class="search glyphicon glyphicon-search form-control-feedback"></span>
+        </div>
     </div>
 </div>
 

--- a/src/app-frontend/webpack.common.config.js
+++ b/src/app-frontend/webpack.common.config.js
@@ -65,7 +65,8 @@ module.exports = {
         new Webpack.ProvidePlugin({
             jQuery: "jquery",
             "window.jQuery": "jquery",
-            L: "leaflet"
+            L: "leaflet",
+            toastr: "toastr"
         }),
         new ExtractTextPlugin('css/main.css', {allChunks: true}),
         new BundleTracker({path: outputDir, filename: 'webpack-stats.json'}),


### PR DESCRIPTION
The Google base map already requires the inclusion of the Google Maps API so we are opting to use it for geocoding as well.

To keep things simple we are always choosing the first result from the geocoder.

We convert a stream of location searches into a stream of lat/lng points and then convert that point stream into a stream of bounding boxes creating a 10,000 meter wide box centered on the point. This area is roughly city-sized and is the value that we have been using as the default are for new OpenTreeMap instances.

---

##### Testing

- Entering "phila" in the "Jump to a location" box and pressing "Enter" moves the map to the first result returned by the geocoder.
- Entering "phila" in the "Jump to a location" box should show a dropdown list of suggestions.
- Clicking on an item in the dropdown list of suggestions moves the map to that location.
- Entering "zxyzxyzxy" into the "Jump to location" box and pressing "Enter" shows a toast error message.
- Any overlays and masks selected before moving to a new location are recalculated and reloaded.

---

Connects to #167