### PR TITLE
Conditionally download ZIP code TSV in update and cibuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ project/plugins/target
 project/target
 target
 .ensime
+*.tsv
 
 # Emacs
 \#*#

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ script:
 - mkdir -p ~/.local/bin
 - export PATH="~/.local/bin:$PATH"
 - pip install --user docker-compose==${DOCKER_COMPOSE_VERSION}
+- pip install --user awscli==${AWSCLI_VERSION}
 - scripts/cibuild
 before_deploy:
 - wget -O terraform-${TERRAFORM_VERSION}.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 - unzip -d ~/.local/bin terraform-${TERRAFORM_VERSION}.zip
-- pip install --user awscli==${AWSCLI_VERSION}
 - rm terraform-${TERRAFORM_VERSION}.zip
 deploy:
   provider: script

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -6,8 +6,6 @@ if [[ -n "${GT_TREE_PRIORITIZATION_DEBUG}" ]]; then
     set -x
 fi
 
-DIR="$(dirname "$0")"
-
 function usage() {
     echo -n \
 "Usage: $(basename "$0")
@@ -19,13 +17,20 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-
         echo "Running tests..."
-        "${DIR}/test"
+        ./scripts/test
         echo "Tests complete!"
 
-        echo "Building static site..."
+        if [ ! -d "src/app-backend/server/src/main/resources/masks" ]; then
+            echo "Copying ZIP code TSV"
+            mkdir -p src/app-backend/server/src/main/resources/masks
+            aws s3 cp \
+                s3://geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz \
+                - \
+                | gunzip > src/app-backend/server/src/main/resources/masks/zip-codes.tsv
+        fi
 
+        echo "Building static site..."
         docker-compose run --rm app-frontend install --pure-lockfile
         docker-compose run --rm app-frontend bundle
         echo "Static asset bundle complete!"

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -38,9 +38,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
             docker tag "gt-tree-prioritization-nginx:${VERSION}" \
                 "${AWS_ECR_ENDPOINT}/gt-tree-prioritization-nginx:${VERSION}"
-
             docker tag "gt-tree-prioritization:${VERSION}" \
                 "${AWS_ECR_ENDPOINT}/gt-tree-prioritization:${VERSION}"
+
             docker push "${AWS_ECR_ENDPOINT}/gt-tree-prioritization:${VERSION}"
             docker push "${AWS_ECR_ENDPOINT}/gt-tree-prioritization-nginx:${VERSION}"
         else

--- a/scripts/update
+++ b/scripts/update
@@ -23,6 +23,15 @@ then
         docker-compose \
             run --rm app-frontend install --pure-lockfile
 
+        if [ ! -d "src/app-backend/server/src/main/resources/masks" ]; then
+            echo "Copying ZIP code TSV"
+            mkdir -p src/app-backend/server/src/main/resources/masks
+            aws s3 cp \
+                s3://geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz \
+                - \
+            | gunzip > src/app-backend/server/src/main/resources/masks/zip-codes.tsv
+        fi
+
         echo "Building JAR"
         docker-compose \
             run --rm --entrypoint ./sbt api-server assembly

--- a/scripts/update
+++ b/scripts/update
@@ -32,8 +32,8 @@ then
             | gunzip > src/app-backend/server/src/main/resources/masks/zip-codes.tsv
         fi
 
-        echo "Building JAR"
+        echo "Updating Scala dependencies"
         docker-compose \
-            run --rm --entrypoint ./sbt api-server assembly
+            run --rm --entrypoint ./sbt api-server update
     fi
 fi


### PR DESCRIPTION
When spinning up the project locally, or before the assembly JAR build process, ensure that the TSV of ZIP codes is added to the project `resources/masks` directory.

Fixes https://github.com/geotrellis/tree-prioritization-demo/issues/175

---

1. Execute `update` within Vagrant; this should result in a `.tsv` file within `resources/masks`.
2. Execute `server`
3. Run through the testing steps in https://github.com/geotrellis/tree-prioritization-demo/pull/176

I also tested the assembly JAR. Results should be visible on https://treeprioritization.geotrellis.io.

