### PR TITLE
Add welcome dialog with presets and load presets from the url

### DIFF
--- a/src/app-frontend/assets/css/sass/partials/_modeling.scss
+++ b/src/app-frontend/assets/css/sass/partials/_modeling.scss
@@ -187,6 +187,43 @@ $blue-to-red: #2791c3 10%,
             white-space: nowrap;
         }
     }
+
+    #welcome-dialog {
+        .modal-dialog {
+            width: 80%;
+        }
+
+        .modal-body {
+            overflow-y: auto;
+        }
+
+        .modal-content {
+            padding: 40px;
+        }
+
+        h2 {
+            text-align: center;
+            padding-bottom: 20px;
+        }
+
+        h4 {
+            font-weight: bolder;
+        }
+
+        h5 {
+            padding: 10px;
+            font-weight: bold;
+        }
+
+        input {
+            width: 40%;
+            margin: 0 auto;
+        }
+
+        .featured {
+            text-align: center;
+        }
+    }
 }
 
 #sidebar-prioritization {
@@ -491,4 +528,9 @@ $blue-to-red: #2791c3 10%,
             }
         }
     }
+}
+
+// puts the google places autocomplete dropdown results above the bootstrap modal 1050 zindex.
+.pac-container {
+    z-index: 1051 !important;
 }

--- a/src/app-frontend/js/modeling/prioritizationPresets.js
+++ b/src/app-frontend/js/modeling/prioritizationPresets.js
@@ -20,15 +20,19 @@ var presets = {
 function get(presetId) {
     var preset = presets[presetId];
     if (preset) {
-        return {
-            activeVariables: _.keys(preset),
-            weights: {
-                variables: preset
-            }
-        };
+        return format(preset);
     } else {
         return {};
     }
+}
+
+function format(preset) {
+    return {
+        activeVariables: _.keys(preset),
+        weights: {
+            variables: preset
+        }
+    };
 }
 
 function match(params) {
@@ -39,5 +43,6 @@ function match(params) {
 
 module.exports = {
     get: get,
-    match: match
+    match: match,
+    format: format
 };

--- a/src/app-frontend/template.handlebars
+++ b/src/app-frontend/template.handlebars
@@ -7,6 +7,46 @@
 </head>
 <body id="modeling">
 
+    <div id="welcome-dialog" class="modal fade">
+        <div class="container">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-body">
+                        <h2>GeoTrellis <strong>Tree Prioritization</strong></h2>
+                        <p>Trees provide countless economic, social, and environmental benefits. Discover optimal tree planting locations based on environmental and demographic data.</p>
+                        <p>Using the sidebar on the left of the page, set the priorities that connect to your planting goals, choose the zip codes you would like to see, and view maps displaying possible planting areas.</p>
+                        <div class="featured">
+                            <div class="row">
+                                <div class="col-md-3"></div>
+                                <div class="col-md-6"><hr/></div>
+                                <div class="col-md-3"></div>
+                            </div>
+                            <h5>Explore planting locations in these featured cities</h5>
+                            <div id="locations-container" class="row"></div>
+                            <div class="row">
+                                <div class="col-md-3"></div>
+                                <div class="col-md-6"><hr/></div>
+                                <div class="col-md-3"></div>
+                            </div>
+                            <h5>Or enter a location in the continental US</h5>
+                            <div class="form-group">
+                                <input class="form-control" id="modal-geocode" type="text" placeholder="City, Zip code, Address, etc." name="modal-geocode" value="" autocomplete="off" style="outline: none;">
+                            </div>
+                            <div class="row">
+                                <div class="col-md-3"></div>
+                                <div class="col-md-6"><hr/></div>
+                                <div class="col-md-3"></div>
+                            </div>
+                            <h5>Interested in trees and tech?</h5>
+                            <div><a href="http://www.opentreemap.org">Learn more at OpenTreeMap.org</a></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
 <div class="content map">
     <div class="sidebar" id="sidebar-prioritization">
         <div class="panel-group" id="accordion">
@@ -103,6 +143,23 @@
         </div>
     </div>
 </div>
+
+<script type="text/template" id="locations-tmpl">
+    <% _.each(locations, function(location) { %>
+        <div class="col-md-4">
+            <div>
+                <h4>
+                    <a href="/?center=<%- location.center %>&preset=<%- JSON.stringify(location.preset) %>" data-center="<%- location.center %>" data-preset="<%- JSON.stringify(location.preset) %>">
+                        <%- location.name %>
+                    </a>
+                </h4>
+            </div>
+            <p>
+               <%= location.description %>
+            </p>
+        </div>
+    <% }) %>
+</script>
 
 <script type="text/template" id="variables-tmpl">
     <% _.each(variables, function(variable) { %>


### PR DESCRIPTION
This commit adds two features

- A "welcome" dialog that makes the demo more self-guiding by providing preset
  locations and weighted overlay combinations.
- The ability to load the location and selected layers from the URL, allowing
  for prioritization plans to be shared by copy/paste.

The serialization and deserialization of the layer configuration makes use of the existing preset loading infrastructure.

Layout based on https://marvelapp.com/id8630g/screen/30499096

<img width="1434" alt="screen shot 2017-07-31 at 6 25 28 pm" src="https://user-images.githubusercontent.com/17363/28805288-c8cdae20-761d-11e7-95c8-1d28946ae4d6.png">


---

##### Testing

- Location searching should work from both the welcome dialog and the map.
- The welcome dialog should only appear if there is a `center=` parameter in the query string.
- Clicking a city name on the welcome dialog
  - Zooms to the city.
  - Loads the defined layers.
  - Dismisses the dialog.
- Copying and pasting the URL to a new browser loads the previous map location and selected layers and weights but does not load any masks or transparency settings.

---

Connects to #168 