### PR TITLE
Use HTTPS to download ZIP code TSV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ script:
 - mkdir -p ~/.local/bin
 - export PATH="~/.local/bin:$PATH"
 - pip install --user docker-compose==${DOCKER_COMPOSE_VERSION}
-- pip install --user awscli==${AWSCLI_VERSION}
 - scripts/cibuild
 before_deploy:
 - wget -O terraform-${TERRAFORM_VERSION}.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 - unzip -d ~/.local/bin terraform-${TERRAFORM_VERSION}.zip
+- pip install --user awscli==${AWSCLI_VERSION}
 - rm terraform-${TERRAFORM_VERSION}.zip
 deploy:
   provider: script

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -24,9 +24,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         if [ ! -d "src/app-backend/server/src/main/resources/masks" ]; then
             echo "Copying ZIP code TSV"
             mkdir -p src/app-backend/server/src/main/resources/masks
-            aws s3 cp \
-                s3://geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz \
-                - \
+            wget -qO- https://s3.amazonaws.com/geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz \
                 | gunzip > src/app-backend/server/src/main/resources/masks/zip-codes.tsv
         fi
 

--- a/scripts/update
+++ b/scripts/update
@@ -26,10 +26,8 @@ then
         if [ ! -d "src/app-backend/server/src/main/resources/masks" ]; then
             echo "Copying ZIP code TSV"
             mkdir -p src/app-backend/server/src/main/resources/masks
-            aws s3 cp \
-                s3://geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz \
-                - \
-            | gunzip > src/app-backend/server/src/main/resources/masks/zip-codes.tsv
+            wget -qO- https://s3.amazonaws.com/geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz \
+                | gunzip > src/app-backend/server/src/main/resources/masks/zip-codes.tsv
         fi
 
         echo "Updating Scala dependencies"


### PR DESCRIPTION
Instead of requiring valid AWS API credentials to download the ZIP code TSV, make the TSV file public and download it via HTTPS with `wget`.

Fixes https://github.com/geotrellis/tree-prioritization-demo/issues/179

---

**Testing**

Not really the best indicator (because it failed us last time), but take a pass at the [build output](https://travis-ci.org/geotrellis/tree-prioritization-demo/builds/261849638) to ensure that the new approach works.

Try downloading the TSV file out of band to ensure that it is public:

```bash
$ wget "https://s3.amazonaws.com/geotrellis-site-global-data-us-east-1/tree-prioritization-demo/zip-codes.tsv.gz"
```