### PR TITLE
Show a variant of the welcome dialog when coming from OpenTreeMap

### DIFF
--- a/src/app-frontend/assets/css/sass/partials/_modeling.scss
+++ b/src/app-frontend/assets/css/sass/partials/_modeling.scss
@@ -534,3 +534,8 @@ $blue-to-red: #2791c3 10%,
 .pac-container {
     z-index: 1051 !important;
 }
+
+#start-planning {
+    margin-top: 20px;
+    margin-bottom: 5px;
+}

--- a/src/app-frontend/js/modeling/modeling.js
+++ b/src/app-frontend/js/modeling/modeling.js
@@ -11,6 +11,8 @@ var $ = require('jquery'),
 var dom = {
     geocode: '#geocode',
     modalGeocode: '#modal-geocode',
+    featuredCities: '.featured-cities',
+    startPlanning: '#start-planning',
     welcomeDialog: '#welcome-dialog'
 };
 
@@ -45,10 +47,18 @@ function init() {
         var urlPrefix = 'https://' + window.location.hostname + '/tile/gt/';
     }
 
-    // Only show the welcome dialog if there is no center= query string argument
+    // Hide the featured cities in the modal and show a "Start Planning!" button if
+    // there is already a center parameter in the URL
     if (window.location.search.toLocaleLowerCase().indexOf('center=') < 0) {
+        $(dom.startPlanning).hide();
+    } else {
+        $(dom.featuredCities).hide();
+    }
+    // Only show the welcome dialog if there is no preset= query string argument
+    if (window.location.search.toLocaleLowerCase().indexOf('preset=') < 0) {
         $(dom.welcomeDialog).modal();
-    };
+    }
+
 
     var preset = undefined;
     try {

--- a/src/app-frontend/template.handlebars
+++ b/src/app-frontend/template.handlebars
@@ -16,13 +16,16 @@
                         <p>Trees provide countless economic, social, and environmental benefits. Discover optimal tree planting locations based on environmental and demographic data.</p>
                         <p>Using the sidebar on the left of the page, set the priorities that connect to your planting goals, choose the zip codes you would like to see, and view maps displaying possible planting areas.</p>
                         <div class="featured">
-                            <div class="row">
+                            <div class="row featured-cities">
                                 <div class="col-md-3"></div>
                                 <div class="col-md-6"><hr/></div>
                                 <div class="col-md-3"></div>
                             </div>
-                            <h5>Explore planting locations in these featured cities</h5>
-                            <div id="locations-container" class="row"></div>
+                            <h5 class="featured-cities">Explore planting locations in these featured cities</h5>
+                            <div id="locations-container" class="row featured-cities"></div>
+                            <div class="form-group" id="start-planning">
+                              <a data-dismiss="modal" class="btn btn-primary">Start Planning!</a>
+                            </div>
                             <div class="row">
                                 <div class="col-md-3"></div>
                                 <div class="col-md-6"><hr/></div>


### PR DESCRIPTION
When linking to the demo site from OpenTreeMap, we'd like to continue
to show the welcome dialog (but not the featured cities) and show the
location of the tree map the user came from.

In order to continue to not show the welcome dialog when a user shares a
link, we hide the dialog when the preset parameter is present,
instead of the center parameter as we did previously.

Connects to #181