### PR TITLE
Add a button to set the prioritization center to the map center

### DIFF
--- a/src/app-frontend/assets/css/sass/partials/_modeling.scss
+++ b/src/app-frontend/assets/css/sass/partials/_modeling.scss
@@ -73,6 +73,14 @@ $blue-to-red: #2791c3 10%,
                 }
             }
 
+            .recalculate {
+                position: absolute;
+                top: 10px;
+                left: 310px;
+                z-index: 1000;
+                width: 250px;
+            }
+
             .options {
                 position: absolute;
                 top: 16px;

--- a/src/app-frontend/js/modeling/modeling.js
+++ b/src/app-frontend/js/modeling/modeling.js
@@ -6,7 +6,9 @@ var $ = require('jquery'),
     toastr = require('toastr'),
     prioritization = require('./prioritization.js'),
     template = require('./template.js'),
-    geocoder = require('./geocoder.js');
+    geocoder = require('./geocoder.js'),
+
+    centerToBounds = prioritization.centerToBounds;
 
 var dom = {
     geocode: '#geocode',
@@ -18,11 +20,6 @@ require("../../assets/css/sass/main.scss");
 
 require('es6-promise').polyfill(); // https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant
 require('leaflet.gridlayer.googlemutant');
-
-function centerToBounds(center) {
-    // 10,000 meters is a roughly city size boundary
-    return L.latLng(center).toBounds(5000);
-}
 
 function queryStringObject() {
     var params = location.search.substring(1);
@@ -88,6 +85,7 @@ function init() {
     }));
 
     prioritizationInstance.presetChangedStream.onValue(pushPresetToUrl);
+    prioritizationInstance.centerChangedStream.map(centerToParam).onValue(pushCenterParamToUrl);
 
     // Handle selecting a preset on the welcome dialog
     $('body').on('click', 'a[data-center]', function(e){

--- a/src/app-frontend/js/modeling/prioritization.js
+++ b/src/app-frontend/js/modeling/prioritization.js
@@ -27,7 +27,8 @@ var dom = {
     transparencySlider: '.slider.js-transparency',
     priorityThresholdSlider: '.slider.js-priority-threshold',
     rasterMaskCheckboxes: '.js-raster-mask input:checkbox',
-    vectorMaskCheckboxes: '.js-vector-mask input:checkbox'
+    vectorMaskCheckboxes: '.js-vector-mask input:checkbox',
+    recalculate: '#recalculate'
 };
 
 var initialized = false,
@@ -68,6 +69,7 @@ function init(options) {
 
     var locationMaskChangedStream = locationMasks.init(options),
         boundsChangedStream = new Bacon.Bus(),
+        centerChangedBus = new Bacon.Bus(),
         setPresetBus = new Bacon.Bus(),
         parameterChangedStream = Bacon.mergeAll(
             initDropdownStream(dom.weightDropdowns),
@@ -93,6 +95,22 @@ function init(options) {
         .doAction(hideLoadingSpinner)
         .mapError(showErrorMessage)
         .onValue(updatePriorityLayer, _map);
+
+    _map.on('moveend', function (e) {
+        $(dom.recalculate).show();
+    });
+
+    $(dom.recalculate).on('click', function(e){
+        $(dom.recalculate).hide();
+        setBoundsBasedOnMapCenter();
+    });
+
+    function setBoundsBasedOnMapCenter() {
+        var center = _map.getCenter(),
+            bounds = centerToBounds(center);
+        changeBounds(bounds);
+        centerChangedBus.push(center);
+    }
 
     function showLoadingSpinner() {
         _loadingControl.setLoadingText('Processing').show();
@@ -159,6 +177,7 @@ function init(options) {
 
     return {
         presetChangedStream: parameterChangedStream.map(getParamsFromUi).map(toPreset),
+        centerChangedStream: centerChangedBus.toEventStream(),
         setPreset: setPreset
     };
 }
@@ -186,6 +205,11 @@ var getClassBreaks = (function() {
         });
     };
 }());
+
+function centerToBounds(center) {
+    // 10,000 meters is a roughly city size boundary
+    return L.latLng(center).toBounds(5000);
+}
 
 function initTransparencySlider() {
     initSliderStream(dom.transparencySlider)
@@ -614,5 +638,6 @@ function filterByAttribute($items, attName, attValue) {
 }
 
 module.exports = {
-    init: init
+    init: init,
+    centerToBounds: centerToBounds
 };

--- a/src/app-frontend/js/modeling/prioritization.js
+++ b/src/app-frontend/js/modeling/prioritization.js
@@ -66,9 +66,6 @@ function init(options) {
     $(dom.geocode).on('mouseover', function() { _map.dragging.disable(); _map.doubleClickZoom.disable(); });
     $(dom.geocode).on('mouseout', function() { _map.dragging.enable(); _map.doubleClickZoom.enable(); });
 
-    // TODO: Re-enble when tile server accepts a list of zip code names
-    // instead of "polyMask" GeoJSON
-
     var locationMaskChangedStream = locationMasks.init(options),
         boundsChangedStream = new Bacon.Bus(),
         setPresetBus = new Bacon.Bus(),

--- a/src/app-frontend/template.handlebars
+++ b/src/app-frontend/template.handlebars
@@ -141,6 +141,9 @@
             <input class="form-control" id="geocode" type="text" placeholder="Jump to a location" name="geocode" value="" />
             <span class="search glyphicon glyphicon-search form-control-feedback"></span>
         </div>
+        <div class="recalculate form-group">
+            <button id="recalculate" class="btn btn-default" style="display: none;">Recalculate at this location</button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
This is based loosely on the way mobile point-of-interest search applications work. Whenever the user moves the map, we show a button allowing them to set the center of the prioritization breaks calculation to the current map center.

We moved the centerToBounds function to the prioritization module so it could be used within that module as well ass the top-level modeling module.

---

##### Testing

Turn on one prioritization layer.

- The new button appears whenever the map is moved.
- Clicking the button sets the `center=` param in the URL.
- Clicking the button reloads the priority layer with the new center.

---

Connects to #170