### PR TITLE
Remove default value for ssl_certificate_arn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tile.png
 deployment/terraform/.terraform
 deployment/terraform/*.tfstate*
 deployment/terraform/*.tfplan
+*.tfvars

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,42 @@
+# Amazon Web Services Deployment
+
+Amazon Web Services deployment is driven by [Terraform](https://terraform.io/) and the [AWS Command Line Interface (CLI)](http://aws.amazon.com/cli/).
+
+## Table of Contents
+
+* [AWS Credentials](#aws-credentials)
+* [Terraform](#terraform)
+
+## AWS Credentials
+
+Using the AWS CLI, create an AWS profile named `geotrellis`:
+
+```bash
+$ aws --profile geotrellis configure
+AWS Access Key ID [********************]:
+AWS Secret Access Key [********************]:
+Default region name [us-east-1]: us-east-1
+Default output format [None]:
+```
+
+You will be prompted to enter your AWS credentials, along with a default region. These credentials will be used to authenticate calls to the AWS API when using Terraform and the AWS CLI.
+
+## Terraform
+
+Next, use the `infra` wrapper script to lookup the remote state of the infrastructure and assemble a plan for work to be done:
+
+```bash
+$ export GT_TREE_PRIORITIZATION_SETTINGS_BUCKET="geotrellis-site-production-config-us-east-1"
+$ export AWS_PROFILE="geotrellis"
+# TRAVIS_COMMIT is the 7-digit SHA for the commit you want to deploy
+$ export TRAVIS_COMMIT=1a3b5c7
+$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra.sh plan
+```
+
+Once the plan has been assembled, and you agree with the changes, apply it:
+
+```bash
+$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra.sh apply
+```
+
+This will attempt to apply the plan assembled in the previous step using Amazon's APIs. In order to change specific attributes of the infrastructure, inspect the contents of the environment's configuration file in Amazon S3.

--- a/deployment/terraform/tree-prioritization.tf
+++ b/deployment/terraform/tree-prioritization.tf
@@ -4,7 +4,8 @@
 
 # Logs destination for ECS service
 resource "aws_cloudwatch_log_group" "tree_prioritization" {
-  name = "log${var.environment}TreePrioritization"
+  name              = "log${var.environment}TreePrioritization"
+  retention_in_days = "${var.cloudwatch_log_retention_days}"
 
   tags {
     Environment = "${var.environment}"

--- a/deployment/terraform/tree-prioritization.tf
+++ b/deployment/terraform/tree-prioritization.tf
@@ -30,6 +30,10 @@ resource "aws_ecs_task_definition" "tree_prioritization" {
   container_definitions = "${data.template_file.ecs_tree_prioritization_task.rendered}"
 }
 
+data "aws_iam_role" "autoscaling" {
+  role_name = "${var.ecs_autoscaling_role_name}"
+}
+
 module "tree_prioritization_ecs_service" {
   source = "github.com/azavea/terraform-aws-ecs-web-service?ref=0.2.0"
 
@@ -52,7 +56,7 @@ module "tree_prioritization_ecs_service" {
   container_port                 = "443"
   health_check_path              = "/tile/gt/health-check/"
   ecs_service_role_name          = "${data.terraform_remote_state.core.ecs_service_role_name}"
-  ecs_autoscale_role_arn         = "${data.terraform_remote_state.core.ecs_autoscale_role_arn}"
+  ecs_autoscale_role_arn         = "${data.aws_iam_role.autoscaling.arn}"
 
   project     = "Geotrellis Tree Prioritization"
   environment = "${var.environment}"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -27,6 +27,9 @@ variable "cdn_price_class" {
 
 variable "ssl_certificate_arn" {}
 
+variable "cloudwatch_log_retention_days" {
+  default = "30"
+}
 
 variable "tree_prioritization_ecs_desired_count" {
   default = "1"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -25,9 +25,8 @@ variable "cdn_price_class" {
   default = "PriceClass_200"
 }
 
-variable "ssl_certificate_arn" {
-  default = "arn:aws:acm:us-east-1:896538046175:certificate/a416c2af-00dd-4afd-8c71-dd32edefa839"
-}
+variable "ssl_certificate_arn" {}
+
 
 variable "tree_prioritization_ecs_desired_count" {
   default = "1"

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -31,6 +31,10 @@ variable "cloudwatch_log_retention_days" {
   default = "30"
 }
 
+variable "ecs_autoscaling_role_name" {
+  default = "AWSServiceRoleForApplicationAutoScaling_ECSService"
+}
+
 variable "tree_prioritization_ecs_desired_count" {
   default = "1"
 }

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,14 @@
+version: '2.1'
+services:
+  terraform:
+    image: "quay.io/azavea/terraform:0.9.6"
+    volumes:
+      - ~/.aws:/root/.aws
+      - ./:/usr/local/src
+    environment:
+      - AWS_PROFILE=${AWS_PROFILE:-geotrellis}
+      - TRAVIS_COMMIT=${TRAVIS_COMMIT}
+      - GT_TREE_PRIORITIZATION_DEBUG=1
+      - GT_TREE_PRIORITIZATION_SETTINGS_BUCKET=${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET:-geotrellis-site-production-config-us-east-1}
+    working_dir: /usr/local/src
+    entrypoint: bash

--- a/scripts/infra
+++ b/scripts/infra
@@ -33,6 +33,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         case "${1}" in
             plan)
+                aws s3 cp "s3://${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET}/terraform/tree-prioritization/terraform.tfvars" \
+                    "${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET}.tfvars"
+
                 rm -rf .terraform/ terraform.tfstate*
                 terraform init \
                     -backend-config="bucket=${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET}" \
@@ -40,6 +43,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
                 terraform plan \
                           -var="image_version=\"${TRAVIS_COMMIT:0:7}\"" \
+                          -var-file="${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET}.tfvars" \
                           -var="remote_state_bucket=\"${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET}\"" \
                           -out="${GT_TREE_PRIORITIZATION_SETTINGS_BUCKET}.tfplan"
                 ;;


### PR DESCRIPTION
# Overview

This PR removes the default value for `ssl_certificate_arn` (which is now outdated) from `variables.tf`, and updates `scripts/infra` to use a .tfvars file to make it easier to override other defaults in the future.

## Changes
- Remove default value for `ssl_certficate_arn`
- Set CloudWatch log retention policy to 30 days
- Updated `scripts/infra` to use a `.tfvars` file.
- Add `docker-compose.ci.yml` to make it easier to run local deployments.

Fixes #184 

# Testing
- Run `scripts/infra` according to the instructions in the new deployment README, ensure no changes are necessary.
```bash
$ export GT_TREE_PRIORITIZATION_SETTINGS_BUCKET=geotrellis-site-production-config-us-east-1
$ export AWS_PROFILE=geotrellis
$ export TRAVIS_COMMIT=$(git rev-parse --short master)
$ docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan
```

- Visit https://treeprioritization.geotrellis.io. Ensure that the certificate serial number matches the serial number from the ACM console: https://console.aws.amazon.com/acm/home?region=us-east-1#/?id=4704eab3-c3f9-47fc-9568-a70a0038cf60.
<img width="792" alt="screen shot 2018-07-12 at 1 36 30 pm" src="https://user-images.githubusercontent.com/2507188/42649853-cafb3ebc-85d8-11e8-83d9-f809cf7c5ad9.png">
<img width="471" alt="screen shot 2018-07-12 at 10 44 05 am" src="https://user-images.githubusercontent.com/2507188/42649854-cb081ac4-85d8-11e8-8152-7362ff743b87.png">
